### PR TITLE
additional info for the DNSIMPLE tokens for packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ Packet:
  * -e PACKET_AUTH_TOKEN=secret
  * -e TF_VAR_packet_project_id=secret 
  * -e DNSIMPLE_TOKEN=secret
- * -e DNSIMPLE_ACCOUNT=secret   
+ * -e DNSIMPLE_ACCOUNT=secret 
+ 
+ *DNSIMPLE_TOKEN and DNSIMPLE_ACCOUNT are taken from your https://dnsimple.com/ account for the automated dns name resolution.*
 
 GCE/GKE:
  * -e GOOGLE_CREDENTIALS=secret


### PR DESCRIPTION
It is not clear what are the DNSIMPLE tokens for and why do we need them.

Feel free to update to wording to your liking.


btw Is there no way to avoid using dnsimple or maybe use another provider that offers some free account for open source projects?