### PR TITLE
dockerfile: Labels, Alpine, & Multi-stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM crosscloudci/debian-go:latest
-MAINTAINER "Denver Williams <denver@debian.nz>"
+LABEL maintainer="Denver Williams <denver@debian.nz>"
 ENV KUBECTL_VERSION=v1.8.1
 ENV HELM_VERSION=v2.7.2
 #PIN to Commit on Master


### PR DESCRIPTION
This PR includes the following changes:

## The Maintainer Label
The `MAINTAINER` keyword is deprecated, and the Dockerfile has been updated to use `LABEL maintainer` instead.

## Alpine & Multi-stage builds
Two changes were made to the Dockerfile in order to reduce its size:

1. The Dockerfile is now based on Alpine.
2. Multi-stage builds are used to build the Terraform binaries.

The above changes reduces the size of the image from 1.72GB to 465MB.
    
This patch has been tested with the vSphere provider (#150) and verified that the switch to Alpine does not impede at least the standard Terraform binary or the Terraform provider binaries for: vSphere, AWS, Gzip+Base64.

Please note that I made myself the maintainer for the `golang` stage, while @denverwilliams is still listed as the maintainer for the primary stage. I am more than happy to revert this part of the change. I only did it to indicate who should support the build stage.

## Testing
This change should be tested with all of the providers before being considered for merge:

- [ ] AWS
- [ ] GCE
- [ ] OpenStack
- [ ] Packet
- [x] vSphere

cc @denverwilliams 