### PR TITLE
provider/vSphere: Fix incorrect node hostnames

### DIFF
--- a/vsphere/ignition.json
+++ b/vsphere/ignition.json
@@ -20,6 +20,14 @@
     "files": [
       {
         "filesystem": "root",
+        "path": "${hostname_path}",
+        "mode": 420,
+        "contents": {
+          "source": "data:,${hostname}"
+        }
+      },
+      {
+        "filesystem": "root",
         "group": {},
         "path": "/etc/cloud-config.yml",
         "user": {},

--- a/vsphere/modules.tf
+++ b/vsphere/modules.tf
@@ -22,6 +22,8 @@ module "master" {
 
   name                 = "${var.name}"
   count                = "${var.master_node_count}"
+  hostname_suffix      = "${var.name}.${var.cloud_provider}.local"
+  hostname_path        = "/etc/hostname"
   cloud_init           = "${module.master_templates.master_cloud_init}"
   num_cpu              = "${var.master_num_cpu}"
   num_cores_per_socket = "${var.master_num_cores_per_socket}"
@@ -78,6 +80,8 @@ module "worker" {
 
   name                 = "${var.name}"
   count                = "${var.worker_node_count}"
+  hostname_suffix      = "${var.name}.${var.cloud_provider}.local"
+  hostname_path        = "/etc/hostname"
   cloud_init           = "${module.worker_templates.worker_cloud_init}"
   num_cpu              = "${var.worker_num_cpu}"
   num_cores_per_socket = "${var.worker_num_cores_per_socket}"

--- a/vsphere/modules/master/data_sources.tf
+++ b/vsphere/modules/master/data_sources.tf
@@ -26,6 +26,8 @@ data "template_file" "ign" {
   template = "${file("${path.module}/../../ignition.json")}"
 
   vars {
-    cloud_config = "${base64encode(element(split("`", var.cloud_init), count.index))}"
+    hostname      = "${var.name}-master-${count.index + 1}.${var.hostname_suffix}"
+    hostname_path = "${var.hostname_path}"
+    cloud_config  = "${base64encode(element(split("`", var.cloud_init), count.index))}"
   }
 }

--- a/vsphere/modules/master/input.tf
+++ b/vsphere/modules/master/input.tf
@@ -1,4 +1,6 @@
 variable "name" {}
+variable "hostname_suffix" {}
+variable "hostname_path" {}
 variable "count" {}
 variable "cloud_init" {}
 variable "num_cpu" {}

--- a/vsphere/modules/worker/data_sources.tf
+++ b/vsphere/modules/worker/data_sources.tf
@@ -26,6 +26,8 @@ data "template_file" "ign" {
   template = "${file("${path.module}/../../ignition.json")}"
 
   vars {
-    cloud_config = "${base64encode(element(split("`", var.cloud_init), count.index))}"
+    hostname      = "${var.name}-worker-${count.index + 1}.${var.hostname_suffix}"
+    hostname_path = "${var.hostname_path}"
+    cloud_config  = "${base64encode(element(split("`", var.cloud_init), count.index))}"
   }
 }

--- a/vsphere/modules/worker/input.tf
+++ b/vsphere/modules/worker/input.tf
@@ -1,4 +1,6 @@
 variable "name" {}
+variable "hostname_suffix" {}
+variable "hostname_path" {}
 variable "count" {}
 variable "cloud_init" {}
 variable "num_cpu" {}


### PR DESCRIPTION
This patch fixes an issue where the master/worker nodes were not correctly assigned host names due to Ignition boot-strapping cloud-init. Because cloud-init was running much earlier than usual, the host names were not correctly assigned. The fix was to create the file `/etc/hostname` with Ignition. Now the hostnames are:

```shell
Container Linux by CoreOS stable (1688.5.3)
core@akutz-master-1 ~ $ hostname
akutz-master-1.akutz.vsphere.local
```

```shell
Container Linux by CoreOS stable (1688.5.3)
core@akutz-worker-1 ~ $ hostname
akutz-worker-1.akutz.vsphere.local
```

Here's name resolution from my local host:

```shell
$ host akutz-master-1.akutz.vsphere.local
akutz-master-1.akutz.vsphere.local has address 192.168.1.216
```

```shell
$ host akutz-worker-1.akutz.vsphere.local
akutz-worker-1.akutz.vsphere.local has address 192.168.1.218
```

cc @denverwilliams @figo