### PR TITLE
provider/vSphere: Non-Terraform destroy capability

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -419,6 +419,20 @@ elif [[ "$CLOUD_CMD" = "vsphere-deploy" || \
         export TF_VAR_vsphere_aws_region=$VSPHERE_AWS_REGION
     fi
 
+    # If VSPHERE_DESTROY_FORCE is set (true, dryrun) then use the 
+    # destroy script to tear down the environment. This option does 
+    # not require the Terraform state.
+    if [ "${CLOUD_CMD}" = "vsphere-destroy" ] && \
+       [ -n "${VSPHERE_DESTROY_FORCE}" ]; then
+
+        if [ "${BACKEND}" = "file" ]; then
+            export VSPHERE_TFSTATE_PATH="/cncf/data/${NAME}"
+        fi
+
+        time ./destroy-force.sh "${NAME}"
+        exit "${?}"
+    fi
+
     # initialize based on the config type
     if [ "$BACKEND" = "s3" ] ; then
         cp ../s3-backend.tf .

--- a/vsphere/README.md
+++ b/vsphere/README.md
@@ -63,13 +63,14 @@ integration with vSphere via VMC on AWS:
 | `VSPHERE_AWS_ACCESS_KEY_ID` | An AWS account used to deploy/destroy an ELB |
 | `VSPHERE_AWS_SECRET_ACCESS_KEY` | The secret key for `VSPHERE_AWS_ACCESS_KEY_ID` |
 | `VSPHERE_AWS_REGION ` | The AWS region. Defaults to `us-west-2` |
+| `VSPHERE_DESTROY_FORCE` | Set to `true` to destroy a provisioned environment when the Terraform state is unavailable. This value may also be set to `dryrun` to see what actions would be taken without actually taking them. |
 
 ### Deploy
 The following command can be used to provision a Cross-Cloud environment
 to vSphere:
 
 ```shell
-docker run \
+$ docker run \
   --rm \
   --dns 147.75.69.23 --dns 8.8.8.8 \
   -v $(pwd)/data:/cncf/data \
@@ -91,7 +92,7 @@ The following command can be used to deprovision a Cross-Cloud
 environment deployed to VMC on AWS:
 
 ```shell
-docker run \
+$ docker run \
   --rm \
   --dns 147.75.69.23 --dns 8.8.8.8 \
   -v $(pwd)/data:/cncf/data \
@@ -105,5 +106,29 @@ docker run \
   -e BACKEND=file \
   -e NAME=cross-cloud \
   -e COMMAND=destroy \
+  -ti provisioning
+```
+
+### Destroy without Terraform state
+The following command may be used to deprovision a Cross-Cloud
+environment deployed to VMC on AWS when the Terraform state is
+not available:
+
+```shell
+$ docker run \
+  --rm \
+  --dns 147.75.69.23 --dns 8.8.8.8 \
+  -v $(pwd)/data:/cncf/data \
+  -e VSPHERE_SERVER=$VSPHERE_SERVER \
+  -e VSPHERE_USER=$VSPHERE_USER \
+  -e VSPHERE_PASSWORD=$VSPHERE_PASSWORD \
+  -e VSPHERE_AWS_ACCESS_KEY_ID=$VSPHERE_AWS_ACCESS_KEY_ID \
+  -e VSPHERE_AWS_SECRET_ACCESS_KEY=$VSPHERE_AWS_SECRET_ACCESS_KEY \
+  -e VSPHERE_AWS_REGION=$VSPHERE_AWS_REGION \
+  -e CLOUD=vsphere \
+  -e BACKEND=file \
+  -e NAME=cross-cloud \
+  -e COMMAND=destroy \
+  -e VSPHERE_DESTROY_FORCE=true \
   -ti provisioning
 ```

--- a/vsphere/deploy.sh
+++ b/vsphere/deploy.sh
@@ -1,17 +1,30 @@
 #!/bin/sh
 
-docker run \
+# posix complaint
+# verified by https://www.shellcheck.net
+
+# The script requires exactly one argument -- the name of the environment
+# to remove.
+if [ -z "${1}" ]; then
+  echo "usage: ${0} NAME"
+  exit 1
+fi
+
+# The name of the environment to deploy.
+NAME="${1}"
+
+exec docker run \
   --rm \
   --dns 147.75.69.23 --dns 8.8.8.8 \
-  -v $(pwd)/data:/cncf/data \
-  -e VSPHERE_SERVER=$VSPHERE_SERVER \
-  -e VSPHERE_USER=$VSPHERE_USER \
-  -e VSPHERE_PASSWORD=$VSPHERE_PASSWORD \
-  -e VSPHERE_AWS_ACCESS_KEY_ID=$VSPHERE_AWS_ACCESS_KEY_ID \
-  -e VSPHERE_AWS_SECRET_ACCESS_KEY=$VSPHERE_AWS_SECRET_ACCESS_KEY \
-  -e VSPHERE_AWS_REGION=$VSPHERE_AWS_REGION \
+  -v "$(pwd)/data:/cncf/data" \
+  -e VSPHERE_SERVER="${VSPHERE_SERVER}" \
+  -e VSPHERE_USER="${VSPHERE_USER}" \
+  -e VSPHERE_PASSWORD="${VSPHERE_PASSWORD}" \
+  -e VSPHERE_AWS_ACCESS_KEY_ID="${VSPHERE_AWS_ACCESS_KEY_ID}" \
+  -e VSPHERE_AWS_SECRET_ACCESS_KEY="${VSPHERE_AWS_SECRET_ACCESS_KEY}" \
+  -e VSPHERE_AWS_REGION="${VSPHERE_AWS_REGION}" \
   -e CLOUD=vsphere \
   -e COMMAND=deploy \
-  -e NAME=${1:-$(whoami)} \
+  -e NAME="${NAME}" \
   -e BACKEND=file \
   -ti provisioning

--- a/vsphere/destroy-force.sh
+++ b/vsphere/destroy-force.sh
@@ -1,0 +1,273 @@
+#!/bin/sh
+
+# posix complaint
+# verified by https://www.shellcheck.net
+
+################################################################################
+## destroy-force.sh NAME                                                      ##
+##                                                                            ##
+##   This script destroys a provisioned environment manually by:              ##
+##                                                                            ##
+##     1. Using curl to delete DNS resources.                                 ##
+##     2. Using the AWS CLI to remove AWS resources.                          ##
+##     3. Using the VMware GoVC CLI to remove vSphere resources.              ##
+##     4. Removes local Terraform state.                                      ##
+################################################################################
+
+# The script requires exactly one argument -- the name of the environment
+# to remove.
+if [ -z "${1}" ]; then
+  echo "usage: ${0} NAME"
+  exit 1
+fi
+
+# The name of the environment to clean up.
+NAME="${1}"
+
+# Marking this as a dry run results in an actions that *would* occur
+# simply being echoed to stdout.
+if [ "${VSPHERE_DESTROY_FORCE}" = "dryrun" ]; then
+  DRYRUN=true
+fi
+
+
+################################################################################
+##                                DNS Resources                               ##
+################################################################################
+URI_ROOT=http://147.75.69.23:2379/v2/keys/skydns
+URI_PREFIX="${URI_ROOT}/local/vsphere/${NAME}/${NAME}"
+URI_PREFIX_MASTER="${URI_PREFIX}-master"
+URI_PREFIX_WORKER="${URI_PREFIX}-worker"
+
+COUNT_MASTER=${COUNT_MASTER:-3}
+COUNT_WORKER=${COUNT_WORKER:-1}
+
+delete_dns_entries() {
+  for i in $(seq 1 "${2}"); do
+    if curl -sSLI "${1}-${i}" | grep '200 OK' >/dev/null 2>&1; then
+      if [ "${DRYRUN}" = "true" ]; then
+        echo curl -XDELETE "${1}-${i}"
+      else
+        echo "  - ${NAME}-master-${i}.${NAME}.vsphere.local"
+        curl -XDELETE "${1}-${i}"
+      fi
+    fi
+  done
+}
+
+# Delete the DNS entries for the master nodes.
+echo '# deleting DNS entries for master node(s)'
+delete_dns_entries "${URI_PREFIX_MASTER}" "${COUNT_MASTER}"
+
+# Delete the DNS entries for the worker nodes.
+echo
+echo '# deleting DNS entries for worker node(s)'
+delete_dns_entries "${URI_PREFIX_WORKER}" "${COUNT_WORKER}"
+
+
+################################################################################
+##                         AWS Load Balancer Resources                        ##
+################################################################################
+
+# Make sure the AWS environment variables are set.
+export AWS_ACCESS_KEY_ID=${VSPHERE_AWS_ACCESS_KEY_ID}
+export AWS_SECRET_ACCESS_KEY=${VSPHERE_AWS_SECRET_ACCESS_KEY}
+export AWS_DEFAULT_REGION=${VSPHERE_AWS_REGION}
+
+# Parses the ARNs of resources as a result of describing the tags for
+# one or more ARNs.
+get_arns_from_tag_descriptions() {
+  if [ -z "$*" ]; then return; fi
+  aws elbv2 describe-tags --resource-arns "$@" | \
+    jq ".TagDescriptions | \
+      map(select(any(.Tags[]; .Key == \"Environment\" and \
+      .Value == \"${NAME}\" )))" | \
+    jq ".[] | .ResourceArn" | \
+    tr -d '"'
+}
+
+# Get the AWS load balancers.
+get_lb_arns() {
+  # shellcheck disable=SC2046
+  get_arns_from_tag_descriptions \
+    $(aws elbv2 describe-load-balancers | jq ".LoadBalancers | \
+    map(select(any(.;.LoadBalancerName | \
+    startswith(\"xapi\")))) | \
+    .[] | \
+    .LoadBalancerArn" | tr -d '"')
+}
+
+# Get the AWS load balancer target groups.
+get_lb_target_group_arns() {
+  # shellcheck disable=SC2046
+  get_arns_from_tag_descriptions \
+    $(aws elbv2 describe-target-groups | jq ".TargetGroups | \
+    map(select(any(.;.TargetGroupName | \
+    startswith(\"xapi\")))) | \
+    .[] | \
+    .TargetGroupArn" | tr -d '"')
+}
+
+# Get the allocation IDs for the AWS elastic IPs,
+get_elastic_ip_allocation_ids() {
+  aws ec2 describe-addresses | \
+    jq ".Addresses | \
+      map(select(any(.Tags[]; .Key == \"Environment\" and \
+      .Value == \"${NAME}\" )))" | \
+    jq ".[] | .AllocationId" | \
+    tr -d '"'
+}
+
+# Get the load balancer ARNs.
+echo
+echo '# deleting AWS load balancer(s)'
+if arns=$(get_lb_arns) && [ -n "${arns}" ]; then
+  # Delete the load balancers.
+  for arn in ${arns}; do
+    if [ "${DRYRUN}" = "true" ]; then
+      echo aws elbv2 delete-load-balancer --load-balancer-arn "${arn}"
+    else
+      echo "  - ${arn}"
+      aws elbv2 delete-load-balancer --load-balancer-arn "${arn}"
+    fi
+  done
+
+  # Wait until the load balancers are deleted.
+  echo
+  echo '# waiting for deletion of AWS load balancer(s)'
+  if [ "${DRYRUN}" = "true" ]; then
+    # shellcheck disable=SC2086
+    echo aws elbv2 wait load-balancers-deleted --load-balancer-arns ${arns}
+  else
+    # shellcheck disable=SC2086
+    aws elbv2 wait load-balancers-deleted --load-balancer-arns ${arns}
+  fi
+fi
+
+# Delete the target groups.
+echo
+echo '# deleting AWS load balancer target group(s)'
+if arns=$(get_lb_target_group_arns) && [ -n "${arns}" ]; then
+  for arn in ${arns}; do
+    if [ "${DRYRUN}" = "true" ]; then
+      echo aws elbv2 delete-target-group --target-group-arn "${arn}"
+    else
+      echo "  - ${arn}"
+      aws elbv2 delete-target-group --target-group-arn "${arn}"
+    fi
+  done
+fi
+
+# Release the elastic IPs.
+echo
+echo '# deleting AWS elastic IP address(es)'
+if ids=$(get_elastic_ip_allocation_ids) && [ -n "${ids}" ]; then
+  for id in ${ids}; do
+    if [ "${DRYRUN}" = "true" ]; then
+      echo aws ec2 release-address --allocation-id "${id}"
+    else
+      printf "  - ${id}"
+      # It can take a while for AWS to allow the release of the address,
+      # even if the wait command is used above to ensure the load-balancer
+      # is deleted prior to this call. Try 30 times, with a sleep after
+      # each failed attempt to wait 3 second between attempts.
+      for i in $(seq 1 100); do
+        if ! aws ec2 release-address --allocation-id "${id}" 2> /dev/null; then
+          sleep 3
+          printf " ..."
+        else
+          break
+        fi
+      done
+      echo
+    fi
+  done
+fi
+
+
+################################################################################
+##                             vSphere Resources                              ##
+################################################################################
+
+# Define the information used to access the vSphere server.
+export GOVC_USERNAME=${GOVC_USERNAME:-${VSPHERE_USER}}
+export GOVC_PASSWORD=${GOVC_PASSWORD:-${VSPHERE_PASSWORD}}
+export GOVC_URL=${GOVC_URL:-${VSPHERE_SERVER}}
+export GOVC_DEBUG=${GOVC_DEBUG:-false}
+
+# Define the parent datacenter to limit the scope of the govc commands.
+export GOVC_DATACENTER=${GOVC_DATACENTER:-SDDC-Datacenter}
+
+# Define the parent folder to limit scope of the govc command.
+GOVC_ROOT_FOLDER=${GOVC_ROOT_FOLDER:-"/${GOVC_DATACENTER}/vm/Workloads/CNCF Cross-Cloud"}
+
+# Define the folder that contains the VMs.
+GOVC_VM_FOLDER=${GOVC_VM_FOLDER:-"${GOVC_ROOT_FOLDER}/${NAME}"}
+
+# Define the parent resource pool to limit scope of the govc command.
+GOVC_ROOT_RESOURCE_POOL=${GOVC_ROOT_RESOURCE_POOL:-"/${GOVC_DATACENTER}/host/Cluster-1/Resources/Compute-ResourcePool/CNCF Cross-Cloud"}
+
+# Define the parent resource pool to limit scope of the govc command
+# when querying resource pools that match a name.
+export GOVC_RESOURCE_POOL=${GOVC_RESOURCE_POOL:-${GOVC_ROOT_RESOURCE_POOL}}
+
+# Define the resource pool that contains the VMs.
+GOVC_VM_RESOURCE_POOL=${GOVC_VM_RESOURCE_POOL:-${GOVC_ROOT_RESOURCE_POOL}/${NAME}}
+
+# Destroy the VMs.
+echo
+echo '# deleting vSphere VM(s)'
+if vms=$(govc ls "${GOVC_VM_FOLDER}") && [ -n "${vms}" ]; then
+  IFS="$(printf '%b_' '\n')"; IFS="${IFS%_}" && \
+  for vm in ${vms}; do
+    if [ "${DRYRUN}" = "true" ]; then
+      echo govc vm.destroy "'${vm}'"
+    else
+      echo "  - ${vm}"
+      govc vm.destroy "${vm}"
+    fi
+  done
+fi
+
+# Destroy the folder.
+echo
+echo '# deleting vSphere folder(s)'
+if govc object.collect "${GOVC_VM_FOLDER}" >/dev/null 2>&1; then 
+  if [ "${DRYRUN}" = "true" ]; then
+    echo govc object.destroy "'${GOVC_VM_FOLDER}'"
+  else
+    echo "  - ${GOVC_VM_FOLDER}"
+    STDOUT=$(govc object.destroy "${GOVC_VM_FOLDER}" 2>&1)
+    echo "${STDOUT}" | grep '... OK$' >/dev/null 2>&1; MATCH_1=$?
+    echo "${STDOUT}" | grep 'not found$' >/dev/null 2>&1; MATCH_2=$?
+    if [ "${MATCH_1}" -ne "0" ] && [ "${MATCH_2}" -ne "0" ]; then
+      echo "${STDOUT}"
+    fi
+  fi
+fi
+
+# Destroy the resource pool.
+echo
+echo '# deleting vSphere resource pool(s)'
+if govc object.collect "${GOVC_VM_RESOURCE_POOL}" >/dev/null 2>&1; then 
+  if [ "${DRYRUN}" = "true" ]; then
+    echo govc pool.destroy "'${GOVC_VM_RESOURCE_POOL}'"
+  else
+    echo "  - ${GOVC_VM_RESOURCE_POOL}"
+    govc pool.destroy "${GOVC_VM_RESOURCE_POOL}"
+  fi
+fi
+
+# If the environment variable VSPHERE_TFSTATE_PATH is set then
+# check to see if it is a valid file path, and if so, treat it 
+# as the Terraform file/directory to be removed.
+echo
+echo '# deleting Terraform state'
+if [ -e "${VSPHERE_TFSTATE_PATH}" ]; then
+  if [ "${DRYRUN}" = "true" ]; then
+    echo rm -fr "${VSPHERE_TFSTATE_PATH}"
+  else
+    echo "  - ${VSPHERE_TFSTATE_PATH}"
+    rm -fr "${VSPHERE_TFSTATE_PATH}"
+  fi
+fi

--- a/vsphere/destroy.sh
+++ b/vsphere/destroy.sh
@@ -1,17 +1,31 @@
 #!/bin/sh
 
-docker run \
+# posix complaint
+# verified by https://www.shellcheck.net
+
+# The script requires exactly one argument -- the name of the environment
+# to remove.
+if [ -z "${1}" ]; then
+  echo "usage: ${0} NAME"
+  exit 1
+fi
+
+# The name of the environment to destroy.
+NAME="${1}"
+
+exec docker run \
   --rm \
   --dns 147.75.69.23 --dns 8.8.8.8 \
-  -v $(pwd)/data:/cncf/data \
-  -e VSPHERE_SERVER=$VSPHERE_SERVER \
-  -e VSPHERE_USER=$VSPHERE_USER \
-  -e VSPHERE_PASSWORD=$VSPHERE_PASSWORD \
-  -e VSPHERE_AWS_ACCESS_KEY_ID=$VSPHERE_AWS_ACCESS_KEY_ID \
-  -e VSPHERE_AWS_SECRET_ACCESS_KEY=$VSPHERE_AWS_SECRET_ACCESS_KEY \
-  -e VSPHERE_AWS_REGION=$VSPHERE_AWS_REGION \
+  -v "$(pwd)/data:/cncf/data" \
+  -e VSPHERE_SERVER="${VSPHERE_SERVER}" \
+  -e VSPHERE_USER="${VSPHERE_USER}" \
+  -e VSPHERE_PASSWORD="${VSPHERE_PASSWORD}" \
+  -e VSPHERE_AWS_ACCESS_KEY_ID="${VSPHERE_AWS_ACCESS_KEY_ID}" \
+  -e VSPHERE_AWS_SECRET_ACCESS_KEY="${VSPHERE_AWS_SECRET_ACCESS_KEY}" \
+  -e VSPHERE_AWS_REGION="${VSPHERE_AWS_REGION}" \
   -e CLOUD=vsphere \
   -e COMMAND=destroy \
-  -e NAME=${1:-$(whoami)} \
+  -e NAME="${NAME}" \
   -e BACKEND=file \
+  -e VSPHERE_DESTROY_FORCE="${VSPHERE_DESTROY_FORCE}" \
   -ti provisioning


### PR DESCRIPTION
This patch introduces the ability to destroy vSphere-provisioned environment without the need for the associated Terraform state. Passing the environment variable `VSPHERE_DESTROY_FORCE=true` to the provision image along with the standard `COMMAND=destroy` causes the environment to be destroyed using the script `vsphere/destroy-force.sh`. This script:

 1. Uses curl to delete the DNS entries from the shared DNS server.
2. Uses the AWS CLI to delete the load balancer and its related resources.
3. Uses the VMware GoVC CLI to delete the vSphere VM(s), resource pool(s), and folder(s).
4. Deletes the local, file-based Terraform state if it exists.

For example:

```shell
# deleting DNS entries for master node(s)
    - akutz-01-master-1.akutz-01.vsphere.local
{"action":"delete","node":{"key":"/skydns/local/vsphere/akutz-01/akutz-01-master-1","modifiedIndex":23286,"createdIndex":23269},"prevNode":{"key":"/skydns/local/vsphere/akutz-01/akutz-01-master-1","value":"{\"host\":\"192.168.1.94\"}","modifiedIndex":23269,"createdIndex":23269}}
    - akutz-01-master-2.akutz-01.vsphere.local
{"action":"delete","node":{"key":"/skydns/local/vsphere/akutz-01/akutz-01-master-2","modifiedIndex":23287,"createdIndex":23268},"prevNode":{"key":"/skydns/local/vsphere/akutz-01/akutz-01-master-2","value":"{\"host\":\"192.168.1.90\"}","modifiedIndex":23268,"createdIndex":23268}}
    - akutz-01-master-3.akutz-01.vsphere.local
{"action":"delete","node":{"key":"/skydns/local/vsphere/akutz-01/akutz-01-master-3","modifiedIndex":23288,"createdIndex":23270},"prevNode":{"key":"/skydns/local/vsphere/akutz-01/akutz-01-master-3","value":"{\"host\":\"192.168.1.93\"}","modifiedIndex":23270,"createdIndex":23270}}

# deleting DNS entries for worker node(s)
    - akutz-01-master-1.akutz-01.vsphere.local
{"action":"delete","node":{"key":"/skydns/local/vsphere/akutz-01/akutz-01-worker-1","modifiedIndex":23289,"createdIndex":23267},"prevNode":{"key":"/skydns/local/vsphere/akutz-01/akutz-01-worker-1","value":"{\"host\":\"192.168.1.88\"}","modifiedIndex":23267,"createdIndex":23267}}

# deleting AWS load balancer(s)
  - arn:aws:elasticloadbalancing:us-west-2:571501312763:loadbalancer/net/xapi-20180708225329339400000002/a7bee33bfb072dfd

# waiting for deletion of AWS load balancer(s)

# deleting AWS load balancer target group(s)
  - arn:aws:elasticloadbalancing:us-west-2:571501312763:targetgroup/xapi-20180708225327117000000001/2841c40b4e8fa93b

# deleting AWS elastic IP address(es)
  - eipalloc-040bc7190873cfc15

# deleting vSphere VM(s)
  - /SDDC-Datacenter/vm/Workloads/CNCF Cross-Cloud/akutz-01/akutz-01-worker-1
  - /SDDC-Datacenter/vm/Workloads/CNCF Cross-Cloud/akutz-01/akutz-01-master-3
  - /SDDC-Datacenter/vm/Workloads/CNCF Cross-Cloud/akutz-01/akutz-01-master-1
  - /SDDC-Datacenter/vm/Workloads/CNCF Cross-Cloud/akutz-01/akutz-01-master-2

# deleting vSphere folder(s)
  - /SDDC-Datacenter/vm/Workloads/CNCF Cross-Cloud/akutz-01

# deleting vSphere resource pool(s)
  - /SDDC-Datacenter/host/Cluster-1/Resources/Compute-ResourcePool/CNCF Cross-Cloud/akutz-01

# deleting Terraform state
  - /cncf/data/akutz-01
```

The environment variable may also be set to `VSPHERE_DESTROY_FORCE=dryrun` in order to print the commands that will be executed, but abstain from actually removing any resources. For example:

```shell
# deleting DNS entries for master node(s)
curl -XDELETE http://147.75.69.23:2379/v2/keys/skydns/local/vsphere/akutz-01/akutz-01-master-1
curl -XDELETE http://147.75.69.23:2379/v2/keys/skydns/local/vsphere/akutz-01/akutz-01-master-2
curl -XDELETE http://147.75.69.23:2379/v2/keys/skydns/local/vsphere/akutz-01/akutz-01-master-3

# deleting DNS entries for worker node(s)
curl -XDELETE http://147.75.69.23:2379/v2/keys/skydns/local/vsphere/akutz-01/akutz-01-worker-1

# deleting AWS load balancer(s)
aws elbv2 delete-load-balancer --load-balancer-arn arn:aws:elasticloadbalancing:us-west-2:571501312763:loadbalancer/net/xapi-20180708225329339400000002/a7bee33bfb072dfd

# waiting for deletion of AWS load balancer(s)
aws elbv2 wait load-balancers-deleted --load-balancer-arns arn:aws:elasticloadbalancing:us-west-2:571501312763:loadbalancer/net/xapi-20180708225329339400000002/a7bee33bfb072dfd

# deleting AWS load balancer target group(s)
aws elbv2 delete-target-group --target-group-arn arn:aws:elasticloadbalancing:us-west-2:571501312763:targetgroup/xapi-20180708225327117000000001/2841c40b4e8fa93b

# deleting AWS elastic IP address(es)
aws ec2 release-address --allocation-id eipalloc-040bc7190873cfc15

# deleting vSphere VM(s)
govc vm.destroy '/SDDC-Datacenter/vm/Workloads/CNCF Cross-Cloud/akutz-01/akutz-01-worker-1'
govc vm.destroy '/SDDC-Datacenter/vm/Workloads/CNCF Cross-Cloud/akutz-01/akutz-01-master-3'
govc vm.destroy '/SDDC-Datacenter/vm/Workloads/CNCF Cross-Cloud/akutz-01/akutz-01-master-1'
govc vm.destroy '/SDDC-Datacenter/vm/Workloads/CNCF Cross-Cloud/akutz-01/akutz-01-master-2'

# deleting vSphere folder(s)
govc object.destroy '/SDDC-Datacenter/vm/Workloads/CNCF Cross-Cloud/akutz-01'

# deleting vSphere resource pool(s)
govc pool.destroy '/SDDC-Datacenter/host/Cluster-1/Resources/Compute-ResourcePool/CNCF Cross-Cloud/akutz-01'

# deleting Terraform state
rm -fr /cncf/data/akutz-01
```