### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ export AWS_DEFAULT_REGION=”YOUR_AWS_DEFAULT_REGION” # eg. ap-southeast-2
 ```bash
 docker run \
   -v /tmp/data:/cncf/data \
-  -e NAME=cross-cloud
+  -e NAME=cross-cloud \
   -e CLOUD=aws    \
   -e COMMAND=deploy \
   -e BACKEND=file  \ 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ docker run \
   -e CLOUD=aws    \
   -e COMMAND=deploy \
   -e BACKEND=file  \ 
-  -e AWS_ACCESS_KEY_ID= $AWS_ACCESS_KEY_ID    \
+  -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID    \
   -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY    \
   -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION    \
   -ti registry.cncf.ci/cncf/cross-cloud/provisioning:production


### PR DESCRIPTION
- Added backslash(\\) in setup command `for provision a Kubernetes cluster on AWS`
- Remove extra `space` in command for `provision a Kubernetes cluster on AWS`