### PR TITLE
Replace double inverted comma in GCP in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker run \
   -e BACKEND=file  \ 
   -e GOOGLE_REGION=us-central1    \
   -e GOOGLE_PROJECT=test-cncf-cross-cloud  \
-  -e GOOGLE_CREDENTIALS=”${GOOGLE_CREDENTIALS}”
+  -e GOOGLE_CREDENTIALS="${GOOGLE_CREDENTIALS}" \
   -ti registry.cncf.ci/cncf/cross-cloud/provisioning:production
 ```
 


### PR DESCRIPTION
- Existing double inverted comma is not supported in terminal
 replacing it with default

- missing backslash, ( `\` ), in `GCE` section

Signed-off-by: harshvkarn <harshvkarn54@gmail.com>