### PR TITLE
missing zone error in GCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ docker run \
   -e COMMAND=deploy  \
   -e BACKEND=file  \ 
   -e GOOGLE_REGION=us-central1    \
+  -e GOOGLE_ZONE=us-central1-a  \
   -e GOOGLE_PROJECT=test-cncf-cross-cloud  \
   -e GOOGLE_CREDENTIALS="${GOOGLE_CREDENTIALS}" \
   -ti registry.cncf.ci/cncf/cross-cloud/provisioning:production

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ GCE/GKE:
  * -e GOOGLE_CREDENTIALS=secret
  * -e GOOGLE_REGION=us-central1
  * -e GOOGLE_PROJECT=test-163823
+ * -e GOOGLE_ZONE=us-central1-a
 
 OpenStack:
  * -e TF_VAR_os_auth_url=$OS_AUTH_URL


### PR DESCRIPTION
- Add `GOOGLE_ZONE` in docker run command
Issue: #158

Signed-off-by: harshvkarn <harshvkarn54@gmail.com>