### PR TITLE
provider/vSphere: Make env destroy configurable

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -436,7 +436,12 @@ elif [[ "$CLOUD_CMD" = "vsphere-deploy" || \
         terraform taint -module=kubeconfig null_resource.kubeconfig || true
         time terraform apply -auto-approve ${DIR}/vsphere
     elif [ "$CLOUD_CMD" = "vsphere-destroy" ] ; then
-        time terraform destroy -force ${DIR}/vsphere || true
+        VSPHERE_DESTROY_SKIP=${VSPHERE_DESTROY_SKIP:-${DESTROY_SKIP}}
+        if [ "${VSPHERE_DESTROY_SKIP}" = "true" ]; then
+          echo "vsphere environment destruction disabled"
+        else
+          time terraform destroy -force ${DIR}/vsphere || true
+        fi
         # Exit after destroying resources as further commands cause hang
         exit
     fi


### PR DESCRIPTION
This patch introduces the environment variable `VSPHERE_DESTROY_SKIP`. If set to `true` the deployed environment will not be deleted during the destroy step.
    
This PR fixes #162 and is related to #161; possibly #154.