### PR TITLE
ATD-8 Add OCI into cross-cloud

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,6 +84,12 @@ before_script:
       elif [ $CLOUD == "ibmcloud" ]; then
          echo "kube-dns is already deployed, skipping"
          kubectl create -f ./rbac/helm-rbac.yml || true
+      elif [ $CLOUD == "oci" ]; then
+         kubectl create -f ./rbac/ || true
+         kubectl --namespace kube-system create secret generic oci-cloud-controller-manager --from-file=cloud-provider.yaml=./data/addons/create/oci-ccm-secret.yaml || true
+         kubectl --namespace kube-system create secret generic oci-flexvolume-driver --from-file=config.yaml=./data/addons/create/oci-fvd-secret.yaml || true
+         kubectl --namespace kube-system create secret generic oci-volume-provisioner --from-file=config.yaml=./data/addons/create/oci-vp-secret.yaml || true
+         kubectl apply -f ./data/addons/apply
       else
         kubectl create -f ./rbac/ || true
         kubectl create -f ./addons/ || true
@@ -118,7 +124,7 @@ before_script:
   variables:
     CLOUD: MUST BE SET
   script:
-    - /cncf/provision.sh ${CLOUD}-destroy ${ENVIRONMENT}${DEPLOYMENT_SHA} s3 ${CLOUD} 
+    - /cncf/provision.sh ${CLOUD}-destroy ${ENVIRONMENT}${DEPLOYMENT_SHA} s3 ${CLOUD}
 
 # Build-Source VARs
 Build-Source:
@@ -139,7 +145,7 @@ Provisioning:
 #     name: ${AWS_CLOUD}-${CI_COMMIT_REF_SLUG}
 #     url: https://$CI_ENVIRONMENT_SLUG.demo.cncf.ci/
 
-# AWS Destroy VARs 
+# AWS Destroy VARs
 Kubernetes_destroy:
   <<: *kubernetes_cloud_destroy_template
   variables:

--- a/oci/input.tf
+++ b/oci/input.tf
@@ -52,6 +52,7 @@ variable "master_lb_shape" { default="100Mbps"}
 
 # Kubernetes configuration
 variable "etcd_endpoint" {default = "127.0.0.1"}
+variable "kubelet_cloud_provider" {default = "external"}
 variable "cloud_config" { default = "--cloud-config=/etc/srv/kubernetes/cloud-config" }
 variable "cluster_domain" { default = "cluster.local" }
 variable "pod_cidr" { default = "100.96.0.0/11" }

--- a/oci/modules/addons/addons.tf
+++ b/oci/modules/addons/addons.tf
@@ -1,0 +1,27 @@
+resource "template_dir" "create" {
+  source_dir      = "${path.module}/templates/create"
+  destination_dir = "/cncf/data/addons/create"
+
+  vars {
+    oci_region              = "${var.oci_region}"
+    oci_tenancy_ocid        = "${var.oci_tenancy_ocid}"
+    oci_user_ocid           = "${var.oci_user_ocid}"
+    oci_api_private_key     = "${var.oci_api_private_key}"
+    oci_fingerprint         = "${var.oci_fingerprint}"
+    oci_compartment_ocid    = "${var.oci_compartment_ocid}"
+    oci_vcn_ocid            = "${var.oci_vcn_ocid}"
+    oci_lb_subnet_1_ocid    = "${var.oci_lb_subnet_1_ocid}"
+    oci_lb_subnet_2_ocid    = "${var.oci_lb_subnet_2_ocid}"
+    oci_sl_mgmt_mode        = "${var.oci_sl_mgmt_mode}"
+
+  }
+}
+
+resource "template_dir" "apply" {
+  source_dir      = "${path.module}/templates/apply"
+  destination_dir = "/cncf/data/addons/apply"
+
+  vars {
+
+  }
+}

--- a/oci/modules/addons/input.tf
+++ b/oci/modules/addons/input.tf
@@ -1,0 +1,10 @@
+variable oci_region {}
+variable oci_tenancy_ocid {}
+variable oci_user_ocid {}
+variable oci_api_private_key {}
+variable oci_fingerprint {}
+variable oci_compartment_ocid {}
+variable oci_vcn_ocid {}
+variable oci_lb_subnet_1_ocid {}
+variable oci_lb_subnet_2_ocid {}
+variable oci_sl_mgmt_mode {default = "All"}

--- a/oci/modules/addons/templates/apply/dns-horizontal-autoscaler.yaml
+++ b/oci/modules/addons/templates/apply/dns-horizontal-autoscaler.yaml
@@ -1,0 +1,106 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kube-dns-autoscaler
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kube-dns-autoscaler
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]
+  - apiGroups: [""]
+    resources: ["replicationcontrollers/scale"]
+    verbs: ["get", "update"]
+  - apiGroups: ["extensions"]
+    resources: ["deployments/scale", "replicasets/scale"]
+    verbs: ["get", "update"]
+# Remove the configmaps rule once below issue is fixed:
+# kubernetes-incubator/cluster-proportional-autoscaler#16
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kube-dns-autoscaler
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+subjects:
+  - kind: ServiceAccount
+    name: kube-dns-autoscaler
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: system:kube-dns-autoscaler
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-dns-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns-autoscaler
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-dns-autoscaler
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns-autoscaler
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      priorityClassName: system-cluster-critical
+      containers:
+      - name: autoscaler
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2-r2
+        resources:
+            requests:
+                cpu: "20m"
+                memory: "10Mi"
+        command:
+          - /cluster-proportional-autoscaler
+          - --namespace=kube-system
+          - --configmap=kube-dns-autoscaler
+          # Should keep target in sync with cluster/addons/dns/kube-dns.yaml.base
+          - --target=Deployment/kube-dns
+          # When cluster is using large nodes(with more cores), "coresPerReplica" should dominate.
+          # If using small nodes, "nodesPerReplica" should dominate.
+          - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
+          - --logtostderr=true
+          - --v=2
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      serviceAccountName: kube-dns-autoscaler

--- a/oci/modules/addons/templates/apply/heapster.yml
+++ b/oci/modules/addons/templates/apply/heapster.yml
@@ -1,0 +1,160 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: heapster
+  namespace: kube-system
+  labels:
+    k8s-addon: monitoring-standalone.addons.k8s.io
+    k8s-app: heapster
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    version: v1.7.0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: heapster
+      version: v1.7.0
+  template:
+    metadata:
+      labels:
+        k8s-app: heapster
+        version: v1.7.0
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      serviceAccountName: heapster
+      containers:
+        - image: k8s.gcr.io/heapster:v1.4.0
+          name: heapster
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+              scheme: HTTP
+            initialDelaySeconds: 180
+            timeoutSeconds: 5
+          resources:
+            # keep request = limit to keep this container in guaranteed class
+            limits:
+              cpu: 100m
+              memory: 300Mi
+            requests:
+              cpu: 100m
+              memory: 300Mi
+          command:
+            - /heapster
+            - --source=kubernetes.summary_api:''
+        - image: k8s.gcr.io/addon-resizer:2.0
+          name: heapster-nanny
+          resources:
+            limits:
+              cpu: 50m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /pod_nanny
+            - --cpu=80m
+            - --extra-cpu=0.5m
+            - --memory=140Mi
+            - --extra-memory=4Mi
+            - --deployment=heapster
+            - --container=heapster
+            - --poll-period=300000
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: heapster
+  namespace: kube-system
+  labels:
+    k8s-addon: monitoring-standalone.addons.k8s.io
+    kubernetes.io/name: "Heapster"
+    kubernetes.io/cluster-service: "true"
+spec:
+  ports:
+    - port: 80
+      targetPort: 8082
+  selector:
+    k8s-app: heapster
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: heapster
+  namespace: kube-system
+  labels:
+    k8s-addon: monitoring-standalone.addons.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: heapster
+  labels:
+    k8s-addon: monitoring-standalone.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:heapster
+subjects:
+- kind: ServiceAccount
+  name: heapster
+  namespace: kube-system
+---
+# Heapster's pod_nanny monitors the heapster deployment & its pod(s), and scales
+# the resources of the deployment if necessary.
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: system:pod-nanny
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - "extensions"
+  resources:
+  - deployments
+  verbs:
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: heapster-binding
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:pod-nanny
+subjects:
+- kind: ServiceAccount
+  name: heapster
+  namespace: kube-system

--- a/oci/modules/addons/templates/apply/kube-dns.yml
+++ b/oci/modules/addons/templates/apply/kube-dns.yml
@@ -1,0 +1,244 @@
+---
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Warning: This is a file generated from the base underscore template file: kubedns-svc.yaml.base
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "KubeDNS"
+spec:
+  selector:
+    k8s-app: kube-dns
+  clusterIP: 100.64.0.10
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Should keep target in cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+# in sync with this file.
+
+# Warning: This is a file generated from the base underscore template file: kubedns-controller.yaml.base
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  # replicas: not specified here:
+  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
+  # 2. Default is 1.
+  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
+  strategy:
+    rollingUpdate:
+      maxSurge: 10%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      volumes:
+      - name: kube-dns-config
+        configMap:
+          name: kube-dns
+          optional: true
+      containers:
+      - name: kubedns
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.2
+        resources:
+          # TODO: Set memory limits when we've profiled the container for large
+          # clusters, then set request = limit to keep this container in
+          # guaranteed class. Currently, this container falls into the
+          # "burstable" category so the kubelet doesn't backoff from restarting it.
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        livenessProbe:
+          httpGet:
+            path: /healthcheck/kubedns
+            port: 10054
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 8081
+            scheme: HTTP
+          # we poll on pod startup for the Kubernetes master service and
+          # only setup the /readiness HTTP server once that's available.
+          initialDelaySeconds: 3
+          timeoutSeconds: 5
+        args:
+        - --domain=cluster.local.
+        - --dns-port=10053
+        - --config-dir=/kube-dns-config
+        - --v=2
+        env:
+        - name: PROMETHEUS_PORT
+          value: "10055"
+        ports:
+        - containerPort: 10053
+          name: dns-local
+          protocol: UDP
+        - containerPort: 10053
+          name: dns-tcp-local
+          protocol: TCP
+        - containerPort: 10055
+          name: metrics
+          protocol: TCP
+        volumeMounts:
+        - name: kube-dns-config
+          mountPath: /kube-dns-config
+      - name: dnsmasq
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.2
+        livenessProbe:
+          httpGet:
+            path: /healthcheck/dnsmasq
+            port: 10054
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        args:
+        - -v=2
+        - -logtostderr
+        - -configDir=/etc/k8s/dns/dnsmasq-nanny
+        - -restartDnsmasq=true
+        - --
+        - -k
+        - --cache-size=1000
+        - --log-facility=-
+        - --server=/cluster.local/127.0.0.1#10053
+        - --server=/in-addr.arpa/127.0.0.1#10053
+        - --server=/ip6.arpa/127.0.0.1#10053
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        # see: https://github.com/kubernetes/kubernetes/issues/29055 for details
+        resources:
+          requests:
+            cpu: 150m
+            memory: 20Mi
+        volumeMounts:
+        - name: kube-dns-config
+          mountPath: /etc/k8s/dns/dnsmasq-nanny
+      - name: sidecar
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.2
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 10054
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        args:
+        - --v=2
+        - --logtostderr
+        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.cluster.local,5,A
+        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.cluster.local,5,A
+        ports:
+        - containerPort: 10054
+          name: metrics
+          protocol: TCP
+        resources:
+          requests:
+            memory: 20Mi
+            cpu: 10m
+      dnsPolicy: Default  # Don't use cluster DNS.
+      serviceAccountName: kube-dns
+---
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists

--- a/oci/modules/addons/templates/apply/oci-cloud-controller-manager-rbac.yaml
+++ b/oci/modules/addons/templates/apply/oci-cloud-controller-manager-rbac.yaml
@@ -1,0 +1,120 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: system:cloud-controller-manager
+  labels:
+    kubernetes.io/cluster-service: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - '*'
+
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - watch
+  - patch
+
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - update
+
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+
+# For leader election
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  resourceNames:
+  - "cloud-controller-manager"
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - "cloud-controller-manager"
+  verbs:
+  - get
+  - update
+
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+
+# For the PVL
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - list
+  - watch
+  - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: oci-cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system

--- a/oci/modules/addons/templates/apply/oci-cloud-controller-manager.yaml
+++ b/oci/modules/addons/templates/apply/oci-cloud-controller-manager.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: oci-cloud-controller-manager
+  namespace: kube-system
+  labels:
+    k8s-app: oci-cloud-controller-manager
+spec:
+  selector:
+    matchLabels:
+      k8s-app: oci-cloud-controller-manager
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        k8s-app: oci-cloud-controller-manager
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/role: master
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: "node-role.kubernetes.io/master"
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: cloud-controller-manager
+      containers:
+        - name: oci-cloud-controller-manager
+          image: iad.ocir.io/oracle/oci-cloud-controller-manager:0.6.1
+          args:
+            - --cloud-config=/etc/oci/cloud-provider.yaml
+            - --cloud-provider=oci
+            - --leader-elect-resource-lock=configmaps
+            - -v=2
+          volumeMounts:
+            - name: cfg
+              mountPath: /etc/oci
+              readOnly: true
+            - name: kubernetes
+              mountPath: /etc/kubernetes
+              readOnly: true
+      volumes:
+        - name: cfg
+          secret:
+            secretName: oci-cloud-controller-manager
+        - name: kubernetes
+          hostPath:
+            path: /etc/kubernetes

--- a/oci/modules/addons/templates/apply/oci-flexvolume-driver.yaml
+++ b/oci/modules/addons/templates/apply/oci-flexvolume-driver.yaml
@@ -1,0 +1,74 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: oci-flexvolume-driver-master
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      name: oci-flexvolume-driver-master
+      labels:
+        app: oci-flexvolume-driver
+    spec:
+      nodeSelector:
+        kubernetes.io/role: "master"
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: kubernetes.io/role
+        value: master
+        effect: NoSchedule
+      containers:
+        - image: iad.ocir.io/oracle/oci-flexvolume-driver:0.7.2
+          imagePullPolicy: Always
+          name: oci-flexvolume-driver
+          env:
+            - name: OCI_FLEXD_DRIVER_DIRECTORY
+              value: /var/lib/kubernetes/volumes
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /flexmnt
+              name: flexvolume-mount
+            - mountPath: /tmp
+              name: config
+              readOnly: true
+      volumes:
+        - name: flexvolume-mount
+          hostPath:
+            path: /var/lib/kubernetes/volumes
+            type: DirectoryOrCreate
+        - name: config
+          secret:
+            secretName: oci-flexvolume-driver
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: oci-flexvolume-driver-worker
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      name: oci-flexvolume-driver-worker
+      labels:
+        app: oci-flexvolume-driver
+    spec:
+      containers:
+        - image: iad.ocir.io/oracle/oci-flexvolume-driver:0.7.2
+          imagePullPolicy: Always
+          name: oci-flexvolume-driver
+          env:
+            - name: OCI_FLEXD_DRIVER_DIRECTORY
+              value: /var/lib/kubernetes/volumes
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /flexmnt
+              name: flexvolume-mount
+      volumes:
+        - name: flexvolume-mount
+          hostPath:
+            path: /var/lib/kubernetes/volumes
+            type: DirectoryOrCreate

--- a/oci/modules/addons/templates/apply/oci-volume-provisioner-rbac.yaml
+++ b/oci/modules/addons/templates/apply/oci-volume-provisioner-rbac.yaml
@@ -1,0 +1,40 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: oci-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update", "create"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: run-oracle-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: oci-volume-provisioner
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: oci-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: oci-volume-provisioner
+  namespace: kube-system

--- a/oci/modules/addons/templates/apply/oci-volume-provisioner.yaml
+++ b/oci/modules/addons/templates/apply/oci-volume-provisioner.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: oci-volume-provisioner
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: oci-volume-provisioner
+    spec:
+      serviceAccountName: oci-volume-provisioner
+      containers:
+        - name: oci-volume-provisioner
+          image: iad.ocir.io/oracle/oci-volume-provisioner:0.9.0
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: PROVISIONER_TYPE
+              value: oracle.com/oci
+          volumeMounts:
+            - name: config
+              mountPath: /etc/oci/
+              readOnly: true
+      volumes:
+        - name: config
+          secret:
+            secretName: oci-volume-provisioner

--- a/oci/modules/addons/templates/apply/storage-class-ext3.yaml
+++ b/oci/modules/addons/templates/apply/storage-class-ext3.yaml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: oci-ext3
+provisioner: oracle.com/oci
+parameters:
+  fsType: ext3

--- a/oci/modules/addons/templates/apply/storage-class.yaml
+++ b/oci/modules/addons/templates/apply/storage-class.yaml
@@ -1,0 +1,5 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: oci
+provisioner: oracle.com/oci

--- a/oci/modules/addons/templates/create/oci-ccm-secret.yaml
+++ b/oci/modules/addons/templates/create/oci-ccm-secret.yaml
@@ -1,0 +1,38 @@
+---
+auth:
+  region: ${oci_region}
+  tenancy: ${oci_tenancy_ocid}
+  user: ${oci_user_ocid}
+  key: |
+    ${oci_api_private_key}
+  fingerprint: ${oci_fingerprint}
+
+# compartment configures Compartment within which the cluster resides.
+compartment: ${oci_compartment_ocid}
+
+# vcn configures the Virtual Cloud Network (VCN) within which the cluster resides.
+vcn: ${oci_vcn_ocid}
+
+loadBalancer:
+  # subnet1 configures one of two subnets to which load balancers will be added.
+  # OCI load balancers require two subnets to ensure high availability.
+  subnet1: ${oci_lb_subnet_1_ocid}
+
+  # subnet2 configures the second of two subnets to which load balancers will be
+  # added. OCI load balancers require two subnets to ensure high availability.
+  subnet2: ${oci_lb_subnet_2_ocid}
+
+  # SecurityListManagementMode configures how security lists are managed by the CCM.
+  #   "All" (default): Manage all required security list rules for load balancer services.
+  #   "Frontend":      Manage only security list rules for ingress to the load
+  #                    balancer. Requires that the user has setup a rule that
+  #                    allows inbound traffic to the appropriate ports for kube
+  #                    proxy health port, node port ranges, and health check port ranges.
+  #                    E.g. 10.82.0.0/16 30000-32000.
+  #   "None":          Disables all security list management. Requires that the
+  #                    user has setup a rule that allows inbound traffic to the
+  #                    appropriate ports for kube proxy health port, node port
+  #                    ranges, and health check port ranges. E.g. 10.82.0.0/16 30000-32000.
+  #                    Additionally requires the user to mange rules to allow
+  #                    inbound traffic to load balancers.
+  securityListManagementMode: ${oci_sl_mgmt_mode}

--- a/oci/modules/addons/templates/create/oci-fvd-secret.yaml
+++ b/oci/modules/addons/templates/create/oci-fvd-secret.yaml
@@ -1,0 +1,10 @@
+---
+auth:
+  tenancy: ${oci_tenancy_ocid}
+  compartment: ${oci_compartment_ocid}
+  user: ${oci_user_ocid}
+  region: ${oci_region}
+  key: |
+    ${oci_api_private_key}
+  fingerprint: ${oci_fingerprint}
+  vcn: ${oci_vcn_ocid}

--- a/oci/modules/addons/templates/create/oci-vp-secret.yaml
+++ b/oci/modules/addons/templates/create/oci-vp-secret.yaml
@@ -1,0 +1,8 @@
+---
+auth:
+  tenancy: ${oci_tenancy_ocid}
+  user: ${oci_user_ocid}
+  key: |
+    ${oci_api_private_key}
+  fingerprint: ${oci_fingerprint}
+  region: ${oci_region}

--- a/oci/modules/master/input.tf
+++ b/oci/modules/master/input.tf
@@ -1,9 +1,8 @@
 variable "count" {}
 variable "availability_domain" {}
 variable "compartment_id" {}
-variable "label_prefix" {}
-variable "display_name_prefix" {}
-variable "hostname_label_prefix" {}
+variable "hostname" {}
+variable "hostname_suffix" {}
 variable "image_id" {}
 variable "shape" {}
 variable "subnet_id" {}

--- a/oci/modules/master/master.tf
+++ b/oci/modules/master/master.tf
@@ -2,7 +2,7 @@ resource "oci_core_instance" "K8sMaster" {
   count               = "${var.count}"
   availability_domain = "${var.availability_domain}"
   compartment_id      = "${var.compartment_id}"
-  display_name        = "${var.label_prefix}${var.display_name_prefix}-${count.index}"
+  display_name        = "${ var.hostname }-${ count.index + 1 }.${ var.hostname_suffix }"
   shape               = "${var.shape}"
   subnet_id           = "${var.subnet_id}"
 
@@ -13,24 +13,46 @@ resource "oci_core_instance" "K8sMaster" {
 
   metadata {
     ssh_authorized_keys = "${var.ssh_public_key}"
-    user_data = "${ base64encode(element(split("`", var.master_cloud_init), count.index)) }"
   }
 
   timeouts {
     create = "60m"
   }
 
+  provisioner "file" {
+    connection {
+      type = "ssh"
+      user = "core"
+      private_key = "${var.ssh_private_key}"
+      host = "${self.public_ip}"
+    }
+    content = "${ base64encode(element(split("`", var.master_cloud_init), count.index)) }"
+    destination = "~/user_data"
+  }
+
+  provisioner "file" {
+    connection {
+      type = "ssh"
+      user = "core"
+      private_key = "${var.ssh_private_key}"
+      host = "${self.public_ip}"
+    }
+    content = "REBOOT_STRATEGY=off"
+    destination = "~/update.conf"
+  }
+
   provisioner "remote-exec" {
-    connection{
+    connection {
       type = "ssh"
       user = "core"
       private_key = "${var.ssh_private_key}"
       host = "${self.public_ip}"
     }
     inline = [
-      "wget http://169.254.169.254/opc/v1/instance/metadata/user_data",
       "base64 -d user_data > user_data_decoded",
-      "sudo coreos-cloudinit --from-file user_data_decoded"
+      "sudo coreos-cloudinit --from-file user_data_decoded",
+      "sudo mv ~/update.conf /etc/coreos/",
+      "sudo systemctl restart locksmithd"
     ]
   }
 }

--- a/oci/modules/master_templates-v1.10.0-oci/authentication.tf
+++ b/oci/modules/master_templates-v1.10.0-oci/authentication.tf
@@ -1,0 +1,22 @@
+# Known Tokens
+
+resource "random_string" "admin" {
+  length = 16
+  special = false
+}
+
+resource "random_string" "bootstrap" {
+  length = 16
+  special = false
+}
+
+data "template_file" "known_tokens_csv" {
+  template = "${ file( "${ path.module }/known_tokens.csv" )}"
+
+  vars {
+    admin = "${ random_string.admin.result }"
+    bootstrap = "${ random_string.bootstrap.result }"
+  }
+}
+
+output "bootstrap" { value = "${ random_string.bootstrap.result }" }

--- a/oci/modules/master_templates-v1.10.0-oci/discovery.tf
+++ b/oci/modules/master_templates-v1.10.0-oci/discovery.tf
@@ -1,0 +1,18 @@
+# provider "etcdiscovery" {
+# }
+
+# resource "etcdiscovery_token" "etcd" {
+#   size = "${ var.master_node_count }"
+# }
+
+# output "etcd_discovery" {
+#   value = "${ etcdiscovery_token.etcd.id }"
+# }
+
+# resource "etcdiscovery_token" "etcd_events" {
+#   size = "${ var.master_node_count }"
+# }
+
+# output "etcd_discovery_events" {
+#   value = "${ etcdiscovery_token.etcd_events.id }"
+# }

--- a/oci/modules/master_templates-v1.10.0-oci/etcd-events.yml
+++ b/oci/modules/master_templates-v1.10.0-oci/etcd-events.yml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    k8s-app: etcd-server-events
+  name: etcd-server-events
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - /bin/sh
+    - -c
+    - /usr/local/bin/etcd 1>>/var/log/etcd-events.log 2>&1
+    env:
+    - name: ETCD_NAME
+      value: ${ name }-events
+    - name: ETCD_DISCOVERY_SRV
+      value: ${ etcd_discovery }
+    - name: ETCD_INITIAL_ADVERTISE_PEER_URLS
+      value: http://${ node }.${ etcd_discovery }:2381
+    - name: ETCD_INITIAL_CLUSTER_TOKEN
+      value: ${ name }-events
+    - name: ETCD_INITIAL_CLUSTER_STATE
+      value: new
+    - name: ETCD_ADVERTISE_CLIENT_URLS
+      value: http://${ node }.${ etcd_discovery }:4002
+    - name: ETCD_LISTEN_CLIENT_URLS
+      value: http://0.0.0.0:4002
+    - name: ETCD_LISTEN_PEER_URLS
+      value: http://0.0.0.0:2381
+    - name: ETCD_DATA_DIR
+      value: /var/etcd/data-events
+    image: ${ etcd_image }:${ etcd_tag }
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        path: /health
+        port: 4002
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    name: etcd-container
+    ports:
+    - containerPort: 2381
+      hostPort: 2381
+      name: serverport
+    - containerPort: 4002
+      hostPort: 4002
+      name: clientport
+    resources:
+      requests:
+        cpu: 100m
+    volumeMounts:
+    - mountPath: /etc/ssl/certs
+      name: etcssl
+      readOnly: true
+    - mountPath: /var/etcd/data-events
+      name: varetcdata
+    - mountPath: /var/log
+      name: varlogetcd
+    - mountPath: /etc/srv/kubernetes
+      name: cloudvars
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /usr/share/ca-certificates
+    name: etcssl
+  - hostPath:
+      path: /var/etcd/data-events
+    name: varetcdata
+  - hostPath:
+      path: /var/log
+    name: varlogetcd
+  - hostPath:
+      path: /etc/srv/kubernetes
+    name: cloudvars
+status: {}

--- a/oci/modules/master_templates-v1.10.0-oci/etcd.yml
+++ b/oci/modules/master_templates-v1.10.0-oci/etcd.yml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    k8s-app: etcd-server
+  name: etcd-server
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - /bin/sh
+    - -c
+    - /usr/local/bin/etcd 1>>/var/log/etcd.log 2>&1
+    env:
+    - name: ETCD_NAME
+      value: ${ name }
+    - name: ETCD_DISCOVERY_SRV
+      value: ${ etcd_discovery }
+    - name: ETCD_INITIAL_ADVERTISE_PEER_URLS
+      value: http://${ node }.${ etcd_discovery }:2380
+    - name: ETCD_INITIAL_CLUSTER_TOKEN
+      value: ${ name }-etcd
+    - name: ETCD_INITIAL_CLUSTER_STATE
+      value: new
+    - name: ETCD_ADVERTISE_CLIENT_URLS
+      value: http://${ node }.${ etcd_discovery }:4001
+    - name: ETCD_LISTEN_CLIENT_URLS
+      value: http://0.0.0.0:4001
+    - name: ETCD_LISTEN_PEER_URLS
+      value: http://0.0.0.0:2380
+    - name: ETCD_DATA_DIR
+      value: /var/etcd/data
+    image: ${ etcd_image }:${ etcd_tag }
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        path: /health
+        port: 4001
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    name: etcd-container
+    ports:
+    - containerPort: 2380
+      hostPort: 2380
+      name: serverport
+    - containerPort: 4001
+      hostPort: 4001
+      name: clientport
+    resources:
+      requests:
+        cpu: 200m
+    volumeMounts:
+    - mountPath: /etc/ssl/certs
+      name: etcssl
+      readOnly: true
+    - mountPath: /var/etcd/data
+      name: varetcdata
+    - mountPath: /var/log
+      name: varlogetcd
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /usr/share/ca-certificates
+    name: etcssl
+  - hostPath:
+      path: /var/etcd/data
+    name: varetcdata
+  - hostPath:
+      path: /var/log
+    name: varlogetcd
+status: {}

--- a/oci/modules/master_templates-v1.10.0-oci/input.tf
+++ b/oci/modules/master_templates-v1.10.0-oci/input.tf
@@ -1,0 +1,42 @@
+variable "master_node_count" {}
+variable "name" {}
+variable "hostname" {}
+variable "hostname_suffix" {}
+variable "hostname_path" {}
+
+variable "etcd_endpoint" {}
+variable "etcd_discovery" {}
+
+variable "etcd_artifact" {}
+variable "kube_apiserver_artifact" {}
+variable "kube_controller_manager_artifact" {}
+variable "kube_scheduler_artifact" {}
+variable "kubelet_artifact" {}
+variable "kube_proxy_image" {}
+variable "kube_proxy_tag" {}
+
+variable "cloud_provider" {}
+variable "cloud_config" {}
+variable "cluster_domain" {}
+variable "pod_cidr" {}
+variable "service_cidr" {}
+variable "dns_service_ip" {}
+variable "internal_lb_ip" {}
+variable "non_masquerade_cidr" {}
+variable "cni_artifact" {}
+variable "cni_plugins_artifact" {}
+
+variable "ca" {}
+variable "ca_key" {}
+variable "apiserver" {}
+variable "apiserver_key" {}
+variable "controller" {}
+variable "controller_key" {}
+variable "scheduler" {}
+variable "scheduler_key" {}
+variable "proxy" {}
+variable "proxy_key" {}
+variable "bootstrap" {}
+variable "cloud_config_file" {}
+variable "dns_conf" {}
+variable "dns_dhcp" {}

--- a/oci/modules/master_templates-v1.10.0-oci/known_tokens.csv
+++ b/oci/modules/master_templates-v1.10.0-oci/known_tokens.csv
@@ -1,0 +1,2 @@
+${ admin },admin,admin,system:masters
+${ bootstrap },kubelet-bootstrap,kubelet-bootstrap,system:node-bootstrapper

--- a/oci/modules/master_templates-v1.10.0-oci/kube-apiserver
+++ b/oci/modules/master_templates-v1.10.0-oci/kube-apiserver
@@ -1,0 +1,27 @@
+APISERVER_OPTS="--admission-control=Initializers,NamespaceLifecycle,NodeRestriction,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota \
+--allow-privileged=true \
+--apiserver-count=${ master_node_count } \
+--audit-log-maxage=30 \
+--audit-log-maxbackup=3 \
+--audit-log-maxsize=100 \
+--audit-log-path=/var/log/audit.log \
+--authorization-mode=Node,RBAC \
+--token-auth-file=/etc/srv/kubernetes/known_tokens.csv \
+--bind-address=0.0.0.0 \
+--secure-port=443 \
+--kubelet-preferred-address-types=Hostname \
+--client-ca-file=/etc/srv/kubernetes/pki/ca-certificates.crt \
+--enable-swagger-ui=true \
+--etcd-servers=http://${ etcd_endpoint }:4001 \
+--event-ttl=1h \
+--insecure-bind-address=127.0.0.1 \
+--kubelet-certificate-authority=/etc/srv/kubernetes/pki/ca-certificates.crt \
+--kubelet-client-certificate=/etc/srv/kubernetes/pki/apiserver.crt \
+--kubelet-client-key=/etc/srv/kubernetes/pki/apiserver.key \
+--kubelet-https=true \
+--cloud-provider=${ cloud_provider } ${ cloud_config } \
+--service-account-key-file=/etc/srv/kubernetes/pki/ca-certificates.key \
+--service-cluster-ip-range=${ service_cidr } \
+--tls-cert-file=/etc/srv/kubernetes/pki/apiserver.crt \
+--tls-private-key-file=/etc/srv/kubernetes/pki/apiserver.key \
+--v=2"

--- a/oci/modules/master_templates-v1.10.0-oci/kube-controller-manager
+++ b/oci/modules/master_templates-v1.10.0-oci/kube-controller-manager
@@ -1,0 +1,15 @@
+CONTROLLER_OPTS="--cluster-cidr=${ pod_cidr } \
+--cluster-name=${ cluster_name } \
+--cluster-signing-cert-file=/etc/srv/kubernetes/pki/ca-certificates.crt \
+--cluster-signing-key-file=/etc/srv/kubernetes/pki/ca-certificates.key \
+--leader-elect=true \
+--kubeconfig=/var/lib/kube-controller-manager/kubeconfig \
+--root-ca-file=/etc/srv/kubernetes/pki/ca-certificates.crt \
+--use-service-account-credentials=true \
+--service-account-private-key-file=/etc/srv/kubernetes/pki/ca-certificates.key \
+--service-cluster-ip-range=${ service_cidr } \
+--cloud-provider=${ cloud_provider } ${ cloud_config } \
+--allocate-node-cidrs=true \
+--configure-cloud-routes=true \
+--horizontal-pod-autoscaler-use-rest-clients=false \
+--v=2"

--- a/oci/modules/master_templates-v1.10.0-oci/kube-proxy.yml
+++ b/oci/modules/master_templates-v1.10.0-oci/kube-proxy.yml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ""
+  creationTimestamp: null
+  labels:
+    k8s-app: kube-proxy
+    tier: node
+  name: kube-proxy
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - /bin/sh
+    - -c
+    - kube-proxy --cluster-cidr=${ pod_cidr } --kubeconfig=/var/lib/kube-proxy/kubeconfig --proxy-mode=iptables --v=2 2>&1 | /usr/bin/tee /var/log/kube-proxy.log
+    image: ${ kube_proxy_image }:${ kube_proxy_tag }
+    imagePullPolicy: IfNotPresent
+    name: kube-proxy
+    resources:
+      requests:
+        cpu: 100m
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - mountPath: /var/log
+      name: varlog
+    - mountPath: /var/lib/kube-proxy/kubeconfig
+      name: kubeconfig
+      readOnly: true
+    - mountPath: /etc/srv/kubernetes
+      name: srvkube
+      readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: ssl-certs-hosts
+      readOnly: true
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /var/log
+    name: varlog
+  - hostPath:
+      path: /var/lib/kube-proxy/kubeconfig
+    name: kubeconfig
+  - hostPath:
+      path: /etc/srv/kubernetes
+    name: srvkube
+  - hostPath:
+      path: /usr/share/ca-certificates
+    name: ssl-certs-hosts
+status: {}

--- a/oci/modules/master_templates-v1.10.0-oci/kube-scheduler
+++ b/oci/modules/master_templates-v1.10.0-oci/kube-scheduler
@@ -1,0 +1,3 @@
+SCHEDULER_OPTS="--leader-elect=true \
+--kubeconfig=/var/lib/kube-scheduler/kubeconfig \
+--v=2"

--- a/oci/modules/master_templates-v1.10.0-oci/kubeconfig
+++ b/oci/modules/master_templates-v1.10.0-oci/kubeconfig
@@ -1,0 +1,17 @@
+apiVersion: v1
+clusters:
+- cluster:
+    ${ cluster }
+  name: local
+contexts:
+- context:
+    cluster: local
+    user: ${ user }
+  name: ${ name }
+current-context: ${ name }
+kind: Config
+users:
+- name: ${ user }
+  user:
+    ${ user_authentication }
+

--- a/oci/modules/master_templates-v1.10.0-oci/kubelet
+++ b/oci/modules/master_templates-v1.10.0-oci/kubelet
@@ -1,0 +1,24 @@
+KUBELET_OPTS="--allow-privileged=true \
+--cgroup-root=/ \
+--cloud-provider=${ cloud_provider } ${ cloud_config } \
+--cluster-dns=${ dns_service_ip } \
+--cluster-domain=${ cluster_domain } \
+--enable-debugging-handlers=true \
+--eviction-hard=memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5% \
+--kubeconfig=/var/lib/kubelet/kubeconfig \
+--bootstrap-kubeconfig=/var/lib/kubelet/bootstrap.kubeconfig \
+--network-plugin-mtu=9001 \
+--network-plugin=kubenet \
+--node-labels=kubernetes.io/role=master \
+--non-masquerade-cidr=${ non_masquerade_cidr } \
+--pod-infra-container-image=gcr.io/google_containers/pause-amd64:3.0 \
+--pod-manifest-path=/etc/kubernetes/manifests \
+--register-schedulable=true \
+--register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+--v=2 \
+--cni-bin-dir=/opt/cni/bin/ \
+--cni-conf-dir=/etc/cni/net.d/ \
+--volume-plugin-dir=/etc/kubernetes/volumeplugins \
+--tls-cert-file=/etc/srv/kubernetes/pki/apiserver.crt \
+--tls-private-key-file=/etc/srv/kubernetes/pki/apiserver.key \
+--pod-cidr=--pod-cidr=100.96.0.0/11"

--- a/oci/modules/master_templates-v1.10.0-oci/master.tf
+++ b/oci/modules/master_templates-v1.10.0-oci/master.tf
@@ -1,0 +1,250 @@
+resource "gzip_me" "ca" {
+  input = "${ var.ca }"
+}
+
+resource "gzip_me" "ca_key" {
+  input = "${ var.ca_key }"
+}
+
+resource "gzip_me" "apiserver" {
+  input = "${ var.apiserver }"
+}
+
+resource "gzip_me" "apiserver_key" {
+  input = "${ var.apiserver_key }"
+}
+
+resource "gzip_me" "controller" {
+  input = "${ var.controller }"
+}
+
+resource "gzip_me" "controller_key" {
+  input = "${ var.controller_key }"
+}
+
+resource "gzip_me" "scheduler" {
+  input = "${ var.scheduler }"
+}
+
+resource "gzip_me" "scheduler_key" {
+  input = "${ var.scheduler_key }"
+}
+
+resource "gzip_me" "proxy" {
+  input = "${ var.proxy }"
+}
+
+resource "gzip_me" "proxy_key" {
+  input = "${ var.proxy_key }"
+}
+
+resource "gzip_me" "known_tokens_csv" {
+  input = "${ data.template_file.known_tokens_csv.rendered }"
+}
+
+resource "gzip_me" "dns_conf" {
+  input = "${ var.dns_conf }"
+}
+
+resource "gzip_me" "dns_dhcp" {
+  input = "${ var.dns_dhcp }"
+}
+
+resource "gzip_me" "kube_apiserver" {
+  count = "${ var.master_node_count }"
+  input = "${ element(data.template_file.kube_apiserver.*.rendered, count.index) }"
+}
+
+data "template_file" "kube_apiserver" {
+  count = "${ var.master_node_count }"
+  template = "${ file( "${ path.module }/kube-apiserver" )}"
+  vars {
+    master_node_count = "${ var.master_node_count }"
+    etcd_endpoint = "${ var.etcd_endpoint }"
+    service_cidr = "${ var.service_cidr }"
+    cloud_provider = "${ var.cloud_provider }"
+    cloud_config = "${ var.cloud_config }"
+  }
+}
+
+resource "gzip_me" "kubelet" {
+  count = "${ var.master_node_count }"
+  input = "${ element(data.template_file.kubelet.*.rendered, count.index) }"
+}
+
+data "template_file" "kubelet" {
+  count = "${ var.master_node_count }"
+  template = "${ file( "${ path.module }/kubelet" )}"
+  vars {
+    dns_service_ip = "${ var.dns_service_ip }"
+    cluster_domain = "${ var.cluster_domain }"
+    cloud_provider = "${ var.cloud_provider }"
+    cloud_config = "${ var.cloud_config }"
+    non_masquerade_cidr = "${ var.non_masquerade_cidr }"
+  }
+}
+
+
+
+
+resource "gzip_me" "kube_controller_manager" {
+  input = "${ data.template_file.kube_controller_manager.rendered }"
+}
+
+data "template_file" "kube_controller_manager" {
+  template = "${ file( "${ path.module }/kube-controller-manager" )}"
+  vars {
+    pod_cidr = "${ var.pod_cidr }"
+    service_cidr = "${ var.service_cidr }"
+    cluster_name = "${ var.name }"
+    cloud_provider = "${ var.cloud_provider }"
+    cloud_config = "${ var.cloud_config }"
+  }
+}
+
+
+
+
+resource "gzip_me" "kube_scheduler" {
+  input = "${ data.template_file.kube_scheduler.rendered }"
+}
+
+data "template_file" "kube_scheduler" {
+  template = "${ file( "${ path.module }/kube-scheduler" )}"
+  vars {
+  }
+}
+
+
+
+
+resource "gzip_me" "kube_controller_manager_kubeconfig" {
+  input = "${ data.template_file.kube_controller_manager_kubeconfig.rendered }"
+}
+
+data "template_file" "kube_controller_manager_kubeconfig" {
+  template = "${ file( "${ path.module }/kubeconfig" )}"
+  vars {
+    cluster = "certificate-authority: /etc/srv/kubernetes/pki/ca-certificates.crt \n    server: https://127.0.0.1"
+    user = "kube-controller-manager"
+    name = "service-account-context"
+    user_authentication = "client-certificate: /etc/srv/kubernetes/pki/controller.crt \n    client-key: /etc/srv/kubernetes/pki/controller.key"
+  }
+}
+
+
+
+
+resource "gzip_me" "kube_scheduler_kubeconfig" {
+  input = "${ data.template_file.kube_scheduler_kubeconfig.rendered }"
+}
+
+data "template_file" "kube_scheduler_kubeconfig" {
+  template = "${ file( "${ path.module }/kubeconfig" )}"
+  vars {
+    cluster = "certificate-authority: /etc/srv/kubernetes/pki/ca-certificates.crt \n    server: https://127.0.0.1"
+    user = "kube-scheduler"
+    name = "service-account-context"
+    user_authentication = "client-certificate: /etc/srv/kubernetes/pki/scheduler.crt \n    client-key: /etc/srv/kubernetes/pki/scheduler.key"
+  }
+}
+
+
+
+
+resource "gzip_me" "kubelet_bootstrap_kubeconfig" {
+  input = "${ data.template_file.kubelet_bootstrap_kubeconfig.rendered }"
+}
+
+data "template_file" "kubelet_bootstrap_kubeconfig" {
+  template = "${ file( "${ path.module }/kubeconfig" )}"
+
+  vars {
+    cluster = "certificate-authority: /etc/srv/kubernetes/pki/ca-certificates.crt \n    server: https://${ var.internal_lb_ip }"
+    user = "kubelet-bootstrap"
+    name = "service-account-context"
+    user_authentication = "token: ${ var.bootstrap }"
+  }
+}
+
+
+
+
+resource "gzip_me" "proxy_kubeconfig" {
+  input = "${ data.template_file.proxy_kubeconfig.rendered }"
+}
+
+data "template_file" "proxy_kubeconfig" {
+  template = "${ file( "${ path.module }/kubeconfig" )}"
+
+  vars {
+    cluster = "certificate-authority: /etc/srv/kubernetes/pki/ca-certificates.crt \n    server: https://${ var.internal_lb_ip }"
+    user = "kube-proxy"
+    name = "service-account-context"
+    user_authentication = "client-certificate: /etc/srv/kubernetes/pki/proxy.crt \n    client-key: /etc/srv/kubernetes/pki/proxy.key"
+  }
+}
+
+
+
+
+resource "gzip_me" "kube_proxy" {
+  count = "${ var.master_node_count}"
+  input = "${ element(data.template_file.kube-proxy.*.rendered, count.index) }"
+}
+
+data "template_file" "kube-proxy" {
+  count = "${ var.master_node_count }"
+  template = "${ file( "${ path.module }/kube-proxy.yml" )}"
+
+  vars {
+    master_node = "${ var.internal_lb_ip }"
+    pod_cidr = "${ var.pod_cidr }"
+    kube_proxy_image = "${ var.kube_proxy_image }"
+    kube_proxy_tag = "${ var.kube_proxy_tag }"
+
+  }
+}
+
+data "template_file" "master" {
+  count = "${ var.master_node_count }"
+  template = "${ file( "${ path.module }/master.yml" )}"
+
+  vars {
+    name = "${ var.name }"
+    hostname = "${ var.hostname }-${ count.index + 1 }.${ var.hostname_suffix }"
+    hostname_path = "${ var.hostname_path }"
+    node = "${ var.name }-master-${ count.index +1 }"
+    etcd_artifact = "${ var.etcd_artifact }"
+    etcd_discovery = "${ var.etcd_discovery }"
+    kube_apiserver = "${ element(gzip_me.kube_apiserver.*.output, count.index) }"
+    kube_apiserver_artifact = "${ var.kube_apiserver_artifact }"
+    kube_controller_manager = "${ element(gzip_me.kube_controller_manager.*.output, count.index) }"
+    kube_controller_manager_artifact = "${ var.kube_controller_manager_artifact }"
+    kube_controller_manager_kubeconfig = "${ gzip_me.kube_controller_manager_kubeconfig.output }"
+    kube_scheduler = "${ element(gzip_me.kube_scheduler.*.output, count.index) }"
+    kube_scheduler_artifact = "${ var.kube_scheduler_artifact }"
+    kube_scheduler_kubeconfig = "${ gzip_me.kube_scheduler_kubeconfig.output }"
+    kubelet = "${ element(gzip_me.kubelet.*.output, count.index) }"
+    kubelet_artifact = "${ var.kubelet_artifact }"
+    kubelet_bootstrap_kubeconfig = "${ gzip_me.kubelet_bootstrap_kubeconfig.output }"
+    kube_proxy = "${ element(gzip_me.kube_proxy.*.output, count.index) }"
+    proxy_kubeconfig = "${ gzip_me.proxy_kubeconfig.output }"
+    cni_artifact = "${ var.cni_artifact }"
+    cni_plugins_artifact = "${ var.cni_plugins_artifact }"
+    cloud_config_file = "${ base64gzip(var.cloud_config_file) }"
+    ca = "${ gzip_me.ca.output }"
+    ca_key = "${ gzip_me.ca_key.output }"
+    apiserver = "${ gzip_me.apiserver.output }"
+    apiserver_key = "${ gzip_me.apiserver_key.output }"
+    controller = "${ gzip_me.controller.output }"
+    controller_key = "${ gzip_me.controller_key.output }"
+    scheduler = "${ gzip_me.scheduler.output }"
+    scheduler_key = "${ gzip_me.scheduler_key.output }"
+    proxy = "${ gzip_me.proxy.output }"
+    proxy_key = "${ gzip_me.proxy_key.output }"
+    known_tokens_csv = "${ gzip_me.known_tokens_csv.output }"
+    dns_conf = "${ gzip_me.dns_conf.output }"
+    dns_dhcp = "${ gzip_me.dns_dhcp.output }"
+    }
+}

--- a/oci/modules/master_templates-v1.10.0-oci/master.yml
+++ b/oci/modules/master_templates-v1.10.0-oci/master.yml
@@ -1,0 +1,318 @@
+#cloud-config
+
+---
+hostname: ${ hostname }
+coreos:
+
+  units:
+    - name: systemd-resolved.service
+      command: restart
+
+    - name: systemd-hostnamed.service
+      command: restart
+
+    - name: docker.service
+      command: start
+      drop-ins:
+        - name: docker.conf
+          content: |
+            [Service]
+            EnvironmentFile=/etc/default/docker
+
+    - name: bins.service
+      command: start
+      content: |
+        [Unit]
+        Description=Download Binaries
+        After=network-online.target
+        Requires=network-online.target
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStartPre=/usr/bin/bash -c "while true; do ping -c1 www.google.com > /dev/null && break; done"
+        ExecStartPre=/usr/bin/mkdir --parents /home/kubernetes/bin
+        ExecStartPre=/usr/bin/mkdir --parents /opt/cni/bin
+        ExecStartPre=/usr/bin/mkdir --parents /etc/cni/net.d
+        ExecStart=/usr/bin/curl --retry-max-time 120 -L -o /home/kubernetes/bin/etcd.tar.gz ${ etcd_artifact }
+        ExecStart=/usr/bin/curl --retry-max-time 120 -L -o /home/kubernetes/bin/kube-apiserver ${ kube_apiserver_artifact }
+        ExecStart=/usr/bin/curl --retry-max-time 120 -L -o /home/kubernetes/bin/kube-controller-manager ${ kube_controller_manager_artifact }
+        ExecStart=/usr/bin/curl --retry-max-time 120 -L -o /home/kubernetes/bin/kube-scheduler ${ kube_scheduler_artifact }
+        ExecStart=/usr/bin/curl --retry-max-time 120 -L -o /home/kubernetes/bin/kubelet ${ kubelet_artifact }
+        ExecStart=/usr/bin/curl --retry-max-time 120 -L -o /tmp/cni.tar ${ cni_artifact }
+        ExecStart=/usr/bin/curl --retry-max-time 120 -L -o /tmp/cni-plugins.tar ${ cni_plugins_artifact }
+        ExecStart=/usr/bin/tar -xvf /tmp/cni.tar -C /opt/cni/bin/
+        ExecStart=/usr/bin/tar -xvf /tmp/cni-plugins.tar -C /opt/cni/bin/
+        ExecStart=/usr/bin/tar -xzvf /home/kubernetes/bin/etcd.tar.gz -C /home/kubernetes/bin/ --strip-components=1
+        ExecStart=/usr/bin/chmod +x /home/kubernetes/bin/etcd
+        ExecStart=/usr/bin/chmod +x /home/kubernetes/bin/kube-apiserver
+        ExecStart=/usr/bin/chmod +x /home/kubernetes/bin/kube-controller-manager
+        ExecStart=/usr/bin/chmod +x /home/kubernetes/bin/kube-scheduler
+        ExecStart=/usr/bin/chmod +x /home/kubernetes/bin/kubelet
+
+
+    - name: etcd.service
+      command: start
+      content: |
+        [Unit]
+        Description=etcd
+        Documentation=https://github.com/coreos/etcd
+        After=bins.service
+        Requires=bins.service
+
+        [Service]
+        Type=notify
+        Restart=always
+        RestartSec=10s
+        LimitNOFILE=40000
+        TimeoutStartSec=0
+
+        Environment=ETCD_NAME=${ name }
+        Environment=ETCD_DISCOVERY_SRV=${ etcd_discovery }
+        Environment=ETCD_INITIAL_ADVERTISE_PEER_URLS=http://${ node }.${ etcd_discovery }:2380
+        Environment=ETCD_INITIAL_CLUSTER_TOKEN=${ name }-etcd
+        Environment=ETCD_INITIAL_CLUSTER_STATE=new
+        Environment=ETCD_ADVERTISE_CLIENT_URLS=http://${ node }.${ etcd_discovery }:4001
+        Environment=ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:4001
+        Environment=ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380
+        Environment=ETCD_DATA_DIR=/var/etcd/data
+
+        ExecStart=/home/kubernetes/bin/etcd
+
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: kube-apiserver.service
+      command: start
+      content: |
+        [Unit]
+        Description=Kubernetes API Server
+        Documentation=https://github.com/kubernetes/kubernetes
+        After=bins.service
+        Requires=bins.service
+
+        [Service]
+        EnvironmentFile=/etc/default/kube-apiserver
+        ExecStart=/home/kubernetes/bin/kube-apiserver $APISERVER_OPTS
+
+        Restart=always
+        RestartSec=5
+
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: kube-controller-manager.service
+      command: start
+      content: |
+        [Unit]
+        Description=Kubernetes Controller Manager
+        Documentation=https://github.com/kubernetes/kubernetes
+        After=bins.service
+        Requires=bins.service
+
+        [Service]
+        EnvironmentFile=/etc/default/kube-controller-manager
+        ExecStart=/home/kubernetes/bin/kube-controller-manager $CONTROLLER_OPTS
+
+        Restart=always
+        RestartSec=5
+
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: kube-scheduler.service
+      command: start
+      content: |
+        [Unit]
+        Description=Kubernetes Scheduler
+        Documentation=https://github.com/kubernetes/kubernetes
+        After=bins.service
+        Requires=bins.service
+
+        [Service]
+        EnvironmentFile=/etc/default/kube-scheduler
+        ExecStart=/home/kubernetes/bin/kube-scheduler $SCHEDULER_OPTS
+
+        Restart=always
+        RestartSec=5
+
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: socat.service
+      command: start
+      content: |
+        [Unit]
+        Description=Install Socat
+        After=docker.service
+        Requires=docker.service
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStartPre=/usr/bin/mkdir --parents /opt/bin
+        ExecStart=/usr/bin/docker run --rm -v /opt/bin/:/socat/ registry.cncf.ci/cncf/cross-cloud/socat:production cp /output/linux/x86_64/socat /socat
+
+    - name: kubelet.service
+      command: start
+      content: |
+        [Unit]
+        Description=Kubernetes kubelet
+        After=socat.service
+        Requires=socat.service
+
+        [Service]
+        Restart=always
+        RestartSec=10
+        Environment="PATH=/opt/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        EnvironmentFile=/etc/default/kubelet
+        ExecStart=/home/kubernetes/bin/kubelet $KUBELET_OPTS
+
+        [Install]
+        WantedBy=multi-user.target
+
+  update:
+    reboot-strategy: etcd-lock
+
+
+write-files:
+
+  - path: ${ hostname_path }
+    content: |
+      ${ hostname }
+
+  - path: /etc/default/docker
+    content: |
+      DOCKER_OPTS="--ip-masq=false --iptables=false --log-driver=json-file --log-level=warn --log-opt=max-file=5 --log-opt=max-size=10m --storage-driver=overlay"
+
+  - path: /etc/default/kube-apiserver
+    encoding: "gzip+base64"
+    content: |
+      ${ kube_apiserver }
+
+  - path: /etc/default/kube-controller-manager
+    encoding: "gzip+base64"
+    content: |
+      ${ kube_controller_manager }
+
+  - path: /etc/default/kube-scheduler
+    encoding: "gzip+base64"
+    content: |
+      ${ kube_scheduler }
+
+  - path: /etc/default/kubelet
+    encoding: "gzip+base64"
+    content: |
+      ${ kubelet }
+
+  - path: /var/lib/kubelet/bootstrap.kubeconfig
+    encoding: "gzip+base64"
+    content: |
+      ${ kubelet_bootstrap_kubeconfig }
+
+  - path: /var/lib/kube-controller-manager/kubeconfig
+    encoding: "gzip+base64"
+    content: |
+      ${ kube_controller_manager_kubeconfig }
+
+  - path: /var/lib/kube-scheduler/kubeconfig
+    encoding: "gzip+base64"
+    content: |
+      ${ kube_scheduler_kubeconfig }
+
+  - path: /etc/kubernetes/manifests/kube-proxy.yml
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ kube_proxy }
+
+  - path: /var/lib/kube-proxy/kubeconfig
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ proxy_kubeconfig }
+
+  - path: /etc/srv/kubernetes/pki/ca-certificates.crt
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ ca }
+
+  - path: /etc/srv/kubernetes/pki/ca-certificates.key
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ ca_key }
+
+  - path: /etc/srv/kubernetes/pki/apiserver.crt
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ apiserver }
+
+  - path: /etc/srv/kubernetes/pki/apiserver.key
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ apiserver_key }
+
+  - path: /etc/srv/kubernetes/pki/controller.crt
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ controller }
+
+  - path: /etc/srv/kubernetes/pki/controller.key
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ controller_key }
+
+  - path: /etc/srv/kubernetes/pki/scheduler.crt
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ scheduler }
+
+  - path: /etc/srv/kubernetes/pki/scheduler.key
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ scheduler_key }
+
+  - path: /etc/srv/kubernetes/pki/proxy.crt
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ proxy }
+
+  - path: /etc/srv/kubernetes/pki/proxy.key
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ proxy_key }
+
+  - path: /etc/srv/kubernetes/known_tokens.csv
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ known_tokens_csv }
+
+  - path: /etc/srv/kubernetes/cloud-config
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ cloud_config_file }
+
+  - path: /etc/systemd/resolved.conf.d/dns.conf
+    permissions: 0644
+    encoding: "gzip+base64"
+    owner: root
+    content: |
+      ${ dns_conf }
+
+  - path: /etc/dhcp/dhclient.conf
+    permissions: 0644
+    encoding: "gzip+base64"
+    owner: root
+    content: |
+      ${ dns_dhcp }

--- a/oci/modules/master_templates-v1.10.0-oci/output.tf
+++ b/oci/modules/master_templates-v1.10.0-oci/output.tf
@@ -1,0 +1,1 @@
+output "master_cloud_init" { value = "${ join("`", data.template_file.master.*.rendered) }" }

--- a/oci/modules/network/output.tf
+++ b/oci/modules/network/output.tf
@@ -1,3 +1,6 @@
+output "oci_core_vcn_id" {
+  value = "${oci_core_virtual_network.cross-cloud-vcn.id}"
+}
 output "k8s_subnet_ad1_id" {
   value = "${oci_core_subnet.K8sSubnetAD1.id}"
 }

--- a/oci/modules/ssh/ssh.tf
+++ b/oci/modules/ssh/ssh.tf
@@ -13,6 +13,7 @@ resource "null_resource" "ssh_keys" {
     command = <<LOCAL_EXEC
 echo "${var.ssh_public_key == "" ? join(" ", tls_private_key.ssh.*.public_key_openssh) : var.ssh_public_key}" > "${var.data_dir}/ssh_pub"
 echo "${var.ssh_private_key == "" ? join(" ", tls_private_key.ssh.*.private_key_pem) : var.ssh_private_key}" > "${var.data_dir}/ssh_priv"
+chmod 600 "${var.data_dir}/ssh_priv"
 LOCAL_EXEC
   }
 }

--- a/oci/modules/worker/input.tf
+++ b/oci/modules/worker/input.tf
@@ -1,9 +1,8 @@
 variable "count" {}
 variable "availability_domain" {}
 variable "compartment_id" {}
-variable "label_prefix" {}
-variable "display_name_prefix" {}
-variable "hostname_label_prefix" {}
+variable "hostname" {}
+variable "hostname_suffix" {}
 variable "image_id" {}
 variable "shape" {}
 variable "subnet_id" {}

--- a/oci/modules/worker/worker.tf
+++ b/oci/modules/worker/worker.tf
@@ -2,7 +2,7 @@ resource "oci_core_instance" "K8sWorker" {
   count               = "${var.count}"
   availability_domain = "${var.availability_domain}"
   compartment_id      = "${var.compartment_id}"
-  display_name        = "${var.label_prefix}${var.display_name_prefix}-${count.index}"
+  display_name        = "${ var.hostname }-${ count.index + 1 }.${ var.hostname_suffix }"
   shape               = "${var.shape}"
   subnet_id           = "${var.subnet_id}"
 
@@ -20,7 +20,18 @@ resource "oci_core_instance" "K8sWorker" {
     create = "60m"
   }
 
-    provisioner "remote-exec" {
+  provisioner "file" {
+    connection {
+      type = "ssh"
+      user = "core"
+      private_key = "${var.ssh_private_key}"
+      host = "${self.public_ip}"
+    }
+    content = "REBOOT_STRATEGY=off"
+    destination = "~/update.conf"
+  }
+
+  provisioner "remote-exec" {
     connection{
       type = "ssh"
       user = "core"
@@ -30,7 +41,9 @@ resource "oci_core_instance" "K8sWorker" {
     inline = [
       "wget http://169.254.169.254/opc/v1/instance/metadata/user_data",
       "base64 -d user_data > user_data_decoded",
-      "sudo coreos-cloudinit --from-file user_data_decoded"
+      "sudo coreos-cloudinit --from-file user_data_decoded",
+      "sudo mv ~/update.conf /etc/coreos/",
+      "sudo systemctl restart locksmithd"
     ]
   }
 }

--- a/oci/modules/worker_templates-v1.10.0-oci/input.tf
+++ b/oci/modules/worker_templates-v1.10.0-oci/input.tf
@@ -1,0 +1,29 @@
+variable "worker_node_count" {}
+variable "hostname" {}
+variable "hostname_suffix" {}
+variable "hostname_path" {}
+
+variable "kubelet_artifact" {}
+variable "cni_artifact" {}
+variable "cni_plugins_artifact" {}
+variable "kube_proxy_image" {}
+variable "kube_proxy_tag" {}
+
+variable "cloud_provider" {}
+variable "cloud_config" {}
+variable "cluster_domain" {}
+variable "pod_cidr" {}
+variable "non_masquerade_cidr" {}
+variable "dns_service_ip" {}
+variable "internal_lb_ip" {}
+
+variable "ca" {}
+variable "kubelet" {}
+variable "kubelet_key" {}
+variable "proxy" {}
+variable "proxy_key" {}
+variable "bootstrap" {}
+variable "cloud_config_file" {}
+
+variable "dns_conf" {}
+variable "dns_dhcp" {}

--- a/oci/modules/worker_templates-v1.10.0-oci/kube-proxy.yml
+++ b/oci/modules/worker_templates-v1.10.0-oci/kube-proxy.yml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ""
+  creationTimestamp: null
+  labels:
+    k8s-app: kube-proxy
+    tier: node
+  name: kube-proxy
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - /bin/sh
+    - -c
+    - kube-proxy --cluster-cidr=${ pod_cidr } --kubeconfig=/var/lib/kube-proxy/kubeconfig --proxy-mode=iptables --v=2 2>&1 | /usr/bin/tee /var/log/kube-proxy.log
+    image: ${ kube_proxy_image }:${ kube_proxy_tag }
+    imagePullPolicy: IfNotPresent
+    name: kube-proxy
+    resources:
+      requests:
+        cpu: 100m
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - mountPath: /var/log
+      name: varlog
+    - mountPath: /var/lib/kube-proxy/kubeconfig
+      name: kubeconfig
+      readOnly: true
+    - mountPath: /etc/srv/kubernetes
+      name: srvkube
+      readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: ssl-certs-hosts
+      readOnly: true
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /var/log
+    name: varlog
+  - hostPath:
+      path: /var/lib/kube-proxy/kubeconfig
+    name: kubeconfig
+  - hostPath:
+      path: /etc/srv/kubernetes
+    name: srvkube
+  - hostPath:
+      path: /usr/share/ca-certificates
+    name: ssl-certs-hosts
+status: {}

--- a/oci/modules/worker_templates-v1.10.0-oci/kubeconfig
+++ b/oci/modules/worker_templates-v1.10.0-oci/kubeconfig
@@ -1,0 +1,17 @@
+apiVersion: v1
+clusters:
+- cluster:
+    ${ cluster }
+  name: local
+contexts:
+- context:
+    cluster: local
+    user: ${ user }
+  name: ${ name }
+current-context: ${ name }
+kind: Config
+users:
+- name: ${ user }
+  user:
+    ${ user_authentication }
+

--- a/oci/modules/worker_templates-v1.10.0-oci/kubelet
+++ b/oci/modules/worker_templates-v1.10.0-oci/kubelet
@@ -1,0 +1,22 @@
+KUBELET_OPTS="--allow-privileged=true \
+--anonymous-auth=false \
+--authorization-mode=Webhook \
+--client-ca-file=/etc/srv/kubernetes/pki/ca-certificates.crt \
+--cloud-provider=${ cloud_provider } ${ cloud_config } \
+--cluster-dns=${ dns_service_ip } \
+--cluster-domain=${ cluster_domain } \
+--image-pull-progress-deadline=2m \
+--kubeconfig=/var/lib/kubelet/kubeconfig \
+--bootstrap-kubeconfig=/var/lib/kubelet/bootstrap.kubeconfig \
+--network-plugin=kubenet \
+--network-plugin-mtu=9001 \
+--cni-bin-dir=/opt/cni/bin/ \
+--cni-conf-dir=/etc/cni/net.d/ \
+--node-labels=kubernetes.io/role=node \
+--non-masquerade-cidr=${ non_masquerade_cidr } \
+--pod-manifest-path=/etc/kubernetes/manifests \
+--runtime-request-timeout=15m \
+--volume-plugin-dir=/etc/kubernetes/volumeplugins \
+--tls-cert-file=/etc/srv/kubernetes/pki/kubelet.crt \
+--tls-private-key-file=/etc/srv/kubernetes/pki/kubelet.key \
+--v=2"

--- a/oci/modules/worker_templates-v1.10.0-oci/output.tf
+++ b/oci/modules/worker_templates-v1.10.0-oci/output.tf
@@ -1,0 +1,2 @@
+output "worker_cloud_init" { value = "${ join(",",data.template_file.worker.*.rendered) }" }
+

--- a/oci/modules/worker_templates-v1.10.0-oci/worker.tf
+++ b/oci/modules/worker_templates-v1.10.0-oci/worker.tf
@@ -1,0 +1,140 @@
+resource "gzip_me" "ca" {
+  input = "${ var.ca }"
+}
+
+resource "gzip_me" "kubelet_crt" {
+  input = "${ var.kubelet }"
+}
+
+resource "gzip_me" "kubelet_key" {
+  input = "${ var.kubelet_key }"
+}
+
+resource "gzip_me" "proxy" {
+  input = "${ var.proxy }"
+}
+
+resource "gzip_me" "proxy_key" {
+  input = "${ var.proxy_key }"
+}
+
+resource "gzip_me" "dns_conf" {
+  input = "${ var.dns_conf }"
+}
+
+resource "gzip_me" "dns_dhcp" {
+  input = "${ var.dns_dhcp }"
+}
+
+
+
+
+
+resource "gzip_me" "kubelet" {
+  count = "${ var.worker_node_count }"
+  input = "${ element(data.template_file.kubelet.*.rendered, count.index) }"
+}
+
+data "template_file" "kubelet" {
+  count = "${ var.worker_node_count }"
+  template = "${ file( "${ path.module }/kubelet" )}"
+
+  vars {
+    cluster_domain = "${ var.cluster_domain }"
+    cloud_provider = "${ var.cloud_provider }"
+    cloud_config = "${ var.cloud_config }"
+    dns_service_ip = "${ var.dns_service_ip }"
+    non_masquerade_cidr = "${ var.non_masquerade_cidr }"
+  }
+}
+
+
+
+
+
+
+resource "gzip_me" "kubelet_bootstrap_kubeconfig" {
+  input = "${ data.template_file.kubelet_bootstrap_kubeconfig.rendered }"
+}
+
+data "template_file" "kubelet_bootstrap_kubeconfig" {
+  template = "${ file( "${ path.module }/kubeconfig" )}"
+
+  vars {
+    cluster = "certificate-authority: /etc/srv/kubernetes/pki/ca-certificates.crt \n    server: https://${ var.internal_lb_ip }"
+    user = "kubelet-bootstrap"
+    name = "service-account-context"
+    user_authentication = "token: ${ var.bootstrap }"
+  }
+}
+
+
+
+
+
+resource "gzip_me" "proxy_kubeconfig" {
+  input = "${ data.template_file.proxy_kubeconfig.rendered }"
+}
+
+data "template_file" "proxy_kubeconfig" {
+  template = "${ file( "${ path.module }/kubeconfig" )}"
+
+  vars {
+    cluster = "certificate-authority: /etc/srv/kubernetes/pki/ca-certificates.crt \n    server: https://${ var.internal_lb_ip }"
+    user = "kube-proxy"
+    name = "service-account-context"
+    user_authentication = "client-certificate: /etc/srv/kubernetes/pki/proxy.crt \n    client-key: /etc/srv/kubernetes/pki/proxy.key"
+  }
+}
+
+
+
+
+
+resource "gzip_me" "kube_proxy" {
+  count = "${ var.worker_node_count}"
+  input = "${ element(data.template_file.kube-proxy.*.rendered, count.index) }"
+}
+
+data "template_file" "kube-proxy" {
+  count = "${ var.worker_node_count }"
+  template = "${ file( "${ path.module }/kube-proxy.yml" )}"
+
+  vars {
+    master_node = "${ var.internal_lb_ip }"
+    pod_cidr = "${ var.pod_cidr }"
+    kube_proxy_image = "${ var.kube_proxy_image }"
+    kube_proxy_tag = "${ var.kube_proxy_tag }"
+
+  }
+}
+
+
+
+
+
+data "template_file" "worker" {
+  count = "${ var.worker_node_count }"
+  template = "${ file( "${ path.module }/worker.yml" )}"
+
+  vars {
+    hostname = "${ var.hostname }-${ count.index + 1 }.${ var.hostname_suffix }"
+    hostname_path = "${ var.hostname_path }"
+    cloud_config_file = "${ base64gzip(var.cloud_config_file) }"
+    ca = "${ gzip_me.ca.output }"
+    kubelet_crt = "${ gzip_me.kubelet_crt.output }"
+    kubelet_key = "${ gzip_me.kubelet_key.output }"
+    proxy = "${ gzip_me.proxy.output }"
+    proxy_key = "${ gzip_me.proxy_key.output }"
+    kubelet = "${ element(gzip_me.kubelet.*.output, count.index) }"
+    kubelet_bootstrap_kubeconfig = "${ gzip_me.kubelet_bootstrap_kubeconfig.output }"
+    kube_proxy = "${ element(gzip_me.kube_proxy.*.output, count.index) }"
+    proxy_kubeconfig = "${ gzip_me.proxy_kubeconfig.output }"
+    kubelet_artifact = "${ var.kubelet_artifact }"
+    cni_artifact = "${ var.cni_artifact }"
+    cni_plugins_artifact = "${ var.cni_plugins_artifact }"
+    dns_conf = "${ gzip_me.dns_conf.output }"
+    dns_dhcp = "${ gzip_me.dns_dhcp.output }"
+
+  }
+}

--- a/oci/modules/worker_templates-v1.10.0-oci/worker.yml
+++ b/oci/modules/worker_templates-v1.10.0-oci/worker.yml
@@ -1,0 +1,159 @@
+#cloud-config
+
+---
+hostname: ${ hostname }
+
+coreos:
+
+  units:
+    - name: systemd-resolved.service
+      command: restart
+
+    - name: systemd-hostnamed.service
+      command: restart
+
+    - name: docker.service
+      command: start
+      drop-ins:
+        - name: docker.conf
+          content: |
+            [Service]
+            EnvironmentFile=/etc/default/docker
+
+    - name: bins.service
+      command: start
+      content: |
+        [Unit]
+        Description=Download Binaries
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStartPre=/usr/bin/bash -c "while true; do ping -c1 www.google.com > /dev/null && break; done"
+        ExecStartPre=/usr/bin/mkdir --parents /opt/cni/bin
+        ExecStartPre=/usr/bin/mkdir --parents /etc/cni/net.d
+        ExecStartPre=/usr/bin/mkdir --parents /home/kubernetes/bin
+        ExecStart=/usr/bin/curl --retry-max-time 120 -L -o /home/kubernetes/bin/kubelet ${ kubelet_artifact }
+        ExecStart=/usr/bin/curl --retry-max-time 120 -L -o /tmp/cni.tar ${ cni_artifact }
+        ExecStart=/usr/bin/curl --retry-max-time 120 -L -o /tmp/cni-plugins.tar ${ cni_plugins_artifact }
+        ExecStart=/usr/bin/tar -xvf /tmp/cni.tar -C /opt/cni/bin/
+        ExecStart=/usr/bin/tar -xvf /tmp/cni-plugins.tar -C /opt/cni/bin/
+        ExecStart=/usr/bin/chmod +x /home/kubernetes/bin/kubelet
+
+    - name: socat.service
+      command: start
+      content: |
+        [Unit]
+        Description=Install Socat
+        After=docker.service
+        Requires=docker.service
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStartPre=/usr/bin/mkdir --parents /opt/bin
+        ExecStart=/usr/bin/docker run --rm -v /opt/bin/:/socat/ registry.cncf.ci/cncf/cross-cloud/socat:production cp /output/linux/x86_64/socat /socat
+
+    - name: kubelet.service
+      command: start
+      content: |
+        [Unit]
+        Description=Kubernetes kubelet
+        After=socat.service
+        Requires=socat.service
+
+        [Service]
+        Restart=always
+        RestartSec=10
+        Environment="PATH=/opt/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        EnvironmentFile=/etc/default/kubelet
+        ExecStart=/home/kubernetes/bin/kubelet $KUBELET_OPTS
+
+        [Install]
+        WantedBy=multi-user.target
+
+  update:
+    reboot-strategy: etcd-lock
+
+write-files:
+
+  - path: ${ hostname_path }
+    content: |
+      ${ hostname }
+
+  - path: /etc/default/docker
+    content: |
+      DOCKER_OPTS="--ip-masq=false --iptables=false --log-driver=json-file --log-level=warn --log-opt=max-file=5 --log-opt=max-size=10m --storage-driver=overlay"
+
+  - path: /etc/default/kubelet
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ kubelet }
+
+  - path: /var/lib/kubelet/bootstrap.kubeconfig
+    encoding: "gzip+base64"
+    content: |
+      ${ kubelet_bootstrap_kubeconfig }
+
+  - path: /etc/kubernetes/manifests/kube-proxy.yml
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ kube_proxy }
+
+  - path: /var/lib/kube-proxy/kubeconfig
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ proxy_kubeconfig }
+
+
+  - path: /etc/srv/kubernetes/pki/ca-certificates.crt
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ ca }
+
+  - path: /etc/srv/kubernetes/pki/kubelet.crt
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ kubelet_crt }
+
+  - path: /etc/srv/kubernetes/pki/kubelet.key
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ kubelet_key }
+
+  - path: /etc/srv/kubernetes/pki/proxy.crt
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ proxy }
+
+  - path: /etc/srv/kubernetes/pki/proxy.key
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ proxy_key }
+
+  - path: /etc/srv/kubernetes/cloud-config
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ cloud_config_file }
+
+  - path: /etc/systemd/resolved.conf.d/dns.conf
+    permissions: 0644
+    encoding: "gzip+base64"
+    owner: root
+    content: |
+      ${ dns_conf }
+
+  - path: /etc/dhcp/dhclient.conf
+    permissions: 0644
+    encoding: "gzip+base64"
+    owner: root
+    content: |
+      ${ dns_dhcp }


### PR DESCRIPTION
Add the OCI cloud controller manager, flex volume driver, and volume
provisioner to OCI xcloud clusters. We had to fork the 1.10 templates in
order to work around a CoreOS hostname issue in our downrev image
version and add kubelet back onto the master in order for our
modules to function. The OCI-specific addons are handled with the
addition of a vendor-specific TF module 'addons' that copies and renders the required
files to the container's data mount. The additional steps necessary to
install the addons are then added in a vendor-specific conditional in
the Gitlab CI script.