### PR TITLE
vSphere: No more elastic IPs

### DIFF
--- a/vsphere/deploy.sh
+++ b/vsphere/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# posix complaint
+# posix compliant
 # verified by https://www.shellcheck.net
 
 # The script requires exactly one argument -- the name of the environment

--- a/vsphere/destroy-force.sh
+++ b/vsphere/destroy-force.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# posix complaint
+# posix compliant
 # verified by https://www.shellcheck.net
 
 ################################################################################

--- a/vsphere/destroy.sh
+++ b/vsphere/destroy.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# posix complaint
+# posix compliant
 # verified by https://www.shellcheck.net
 
 # The script requires exactly one argument -- the name of the environment

--- a/vsphere/modules/load_balancer/load_balancer.tf
+++ b/vsphere/modules/load_balancer/load_balancer.tf
@@ -4,24 +4,12 @@ provider "aws" {
   region     = "${var.vsphere_aws_region}"
 }
 
-resource "aws_eip" "xapi" {
-  vpc = true
-
-  tags {
-    Environment = "${var.name}"
-  }
-}
-
 resource "aws_lb" "xapi" {
   name_prefix        = "xapi-"
   load_balancer_type = "network"
   internal           = false
   ip_address_type    = "ipv4"
-
-  subnet_mapping {
-    subnet_id     = "${var.subnet_id}"
-    allocation_id = "${aws_eip.xapi.id}"
-  }
+  subnets            = ["${var.subnet_id}"]
 
   tags {
     Environment = "${var.name}"
@@ -57,4 +45,10 @@ resource "aws_lb_listener" "xapi" {
     target_group_arn = "${aws_lb_target_group.xapi.arn}"
     type             = "forward"
   }
+}
+
+provider "dns" {}
+
+data "dns_a_record_set" "xapi" {
+  host = "${aws_lb.xapi.dns_name}"
 }

--- a/vsphere/modules/load_balancer/output.tf
+++ b/vsphere/modules/load_balancer/output.tf
@@ -1,3 +1,3 @@
 output "public_address" {
-  value = "${aws_eip.xapi.public_ip}"
+  value = "${element(data.dns_a_record_set.xapi.addrs, 0)}"
 }


### PR DESCRIPTION
This patch removes the use of AWS's elastic IPs for vSphere's load balancer. While an IP address *is* required, it's now resolved from the LB's DNS name using the Terraform "dns" provider instead.