### PR TITLE
An easy way to execute kubectl against deployment

### DIFF
--- a/kubectl.sh
+++ b/kubectl.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+exec docker run \
+  --rm \
+  --dns 147.75.69.23 --dns 8.8.8.8 \
+  -v "$(pwd)/data:/cncf/data" \
+  -e KUBECONFIG=/cncf/data/kubeconfig \
+  -ti provisioning \
+  kubectl "${@}"

--- a/provision.sh
+++ b/provision.sh
@@ -9,6 +9,10 @@
 # the rest of the script.
 if [ "$1" = "shell" ]; then exec /bin/bash; fi
 
+# If the first argument is "kubectl" then execute kubectl with any
+# of the remaining arguments.
+if [ "${1}" = "kubectl" ]; then shift; exec /usr/local/bin/kubectl "${@}"; fi
+
 # Initialize the configuration properties based on the command-line
 # arguments OR on the corresponding environment variables.
 CLOUD_CMD=$CLOUD-$COMMAND


### PR DESCRIPTION
This patch provides an easy way to execute `kubectl` against a deployed cluster. Because the deployed clusters depend on a shared DNS server, the only way to access these clusters is for the host running `kubectl` to have the shared DNS server in the list of nameservers. Not all developers may wish to do this. To that end, a new file, `kubectl.sh`, has been created at the root of the project. After deploying a new cluster, this file can be used to access the cluster. Please keep in mind that `kubectl.sh` should be executed from inside a provider directory since the `kubeconfig` file is in the provider's data directory:

```shell
$ ../kubectl.sh get cs
NAME                 STATUS    MESSAGE              ERROR
controller-manager   Healthy   ok
scheduler            Healthy   ok
etcd-0               Healthy   {"health": "true"}
```