### PR TITLE
ATD-332 Change handling of OCI API private key for security purposes

### DIFF
--- a/oci/modules.tf
+++ b/oci/modules.tf
@@ -151,7 +151,6 @@ module "addons" {
   oci_region                                    = "${var.oci_region}"
   oci_tenancy_ocid                              = "${var.oci_tenancy_ocid}"
   oci_user_ocid                                 = "${var.oci_user_ocid}"
-  oci_api_private_key                           = "${indent(4, file("/cncf/keys/oci_api_key.pem"))}"
   oci_fingerprint                               = "${var.oci_fingerprint}"
   oci_compartment_ocid                          = "${module.compartment.compartment_id}"
   oci_vcn_ocid                                  = "${module.network.oci_core_vcn_id}"

--- a/oci/modules/addons/addons.tf
+++ b/oci/modules/addons/addons.tf
@@ -6,7 +6,6 @@ resource "template_dir" "create" {
     oci_region              = "${var.oci_region}"
     oci_tenancy_ocid        = "${var.oci_tenancy_ocid}"
     oci_user_ocid           = "${var.oci_user_ocid}"
-    oci_api_private_key     = "${var.oci_api_private_key}"
     oci_fingerprint         = "${var.oci_fingerprint}"
     oci_compartment_ocid    = "${var.oci_compartment_ocid}"
     oci_vcn_ocid            = "${var.oci_vcn_ocid}"

--- a/oci/modules/addons/input.tf
+++ b/oci/modules/addons/input.tf
@@ -1,7 +1,6 @@
 variable oci_region {}
 variable oci_tenancy_ocid {}
 variable oci_user_ocid {}
-variable oci_api_private_key {}
 variable oci_fingerprint {}
 variable oci_compartment_ocid {}
 variable oci_vcn_ocid {}

--- a/oci/modules/addons/templates/create/oci-ccm-secret.yaml
+++ b/oci/modules/addons/templates/create/oci-ccm-secret.yaml
@@ -4,7 +4,7 @@ auth:
   tenancy: ${oci_tenancy_ocid}
   user: ${oci_user_ocid}
   key: |
-    ${oci_api_private_key}
+    @@oci_api_private_key@@
   fingerprint: ${oci_fingerprint}
 
 # compartment configures Compartment within which the cluster resides.

--- a/oci/modules/addons/templates/create/oci-fvd-secret.yaml
+++ b/oci/modules/addons/templates/create/oci-fvd-secret.yaml
@@ -1,10 +1,10 @@
 ---
 auth:
   tenancy: ${oci_tenancy_ocid}
-  compartment: ${oci_compartment_ocid}
   user: ${oci_user_ocid}
   region: ${oci_region}
   key: |
-    ${oci_api_private_key}
+    @@oci_api_private_key@@
   fingerprint: ${oci_fingerprint}
   vcn: ${oci_vcn_ocid}
+  compartment: ${oci_compartment_ocid}

--- a/oci/modules/addons/templates/create/oci-vp-secret.yaml
+++ b/oci/modules/addons/templates/create/oci-vp-secret.yaml
@@ -3,6 +3,6 @@ auth:
   tenancy: ${oci_tenancy_ocid}
   user: ${oci_user_ocid}
   key: |
-    ${oci_api_private_key}
+    @@oci_api_private_key@@
   fingerprint: ${oci_fingerprint}
   region: ${oci_region}

--- a/provision.sh
+++ b/provision.sh
@@ -562,6 +562,10 @@ elif [[ "$CLOUD_CMD" = "oci-deploy" || \
     _retry "❤ Ensure that ClusterRoles are available" kubectl get ClusterRole.v1.rbac.authorization.k8s.io
     _retry "❤ Ensure that ClusterRoleBindings are available" kubectl get ClusterRoleBinding.v1.rbac.authorization.k8s.io
 
+    # Need to run sed on the secrets files to add the OCI API key so that it doesn't appear in the TF output.
+    sed -e 's/^/    /g' /cncf/keys/oci_api_key.pem > /cncf/keys/oci_api_key_indented.pem
+    sed -i -e '/@@oci_api_private_key@@/r /cncf/keys/oci_api_key_indented.pem' -e '/@@oci_api_private_key@@/d' /cncf/data/addons/create/*.yaml
+    rm -f /cncf/keys/oci_api_key_indented.pem
     kubectl create -f /cncf/rbac/ || true
     kubectl --namespace kube-system create secret generic oci-cloud-controller-manager --from-file=cloud-provider.yaml=/cncf/data/addons/create/oci-ccm-secret.yaml || true
     kubectl --namespace kube-system create secret generic oci-flexvolume-driver --from-file=config.yaml=/cncf/data/addons/create/oci-fvd-secret.yaml || true


### PR DESCRIPTION
It was possible to glean the OCI API private key for the cncf-ci tenancy
from the Gitlab log output. We revoked that key. This change removes the
API key from the TF template handling and moves it to the provision
script. They key should no longer be exposed now.