### PR TITLE
Initial attempt at adding audit-log support to cross-cloud provision

### DIFF
--- a/master_templates-v1.13.0-ubuntu/audit-policy.yaml
+++ b/master_templates-v1.13.0-ubuntu/audit-policy.yaml
@@ -1,0 +1,164 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  # The following requests were manually identified as high-volume and low-risk,
+  # so drop them.
+  - level: None
+    users: ["system:kube-proxy"]
+    verbs: ["watch"]
+    resources:
+      - group: "" # core
+        resources: ["endpoints", "services", "services/status"]
+  - level: None
+    # Ingress controller reads 'configmaps/ingress-uid' through the unsecured port.
+    # TODO(#46983): Change this to the ingress controller service account.
+    users: ["system:unsecured"]
+    namespaces: ["kube-system"]
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["configmaps"]
+  - level: None
+    users: ["kubelet"] # legacy kubelet identity
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["nodes", "nodes/status"]
+  - level: None
+    userGroups: ["system:nodes"]
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["nodes", "nodes/status"]
+  - level: None
+    users:
+      - system:kube-controller-manager
+      - system:kube-scheduler
+      - system:serviceaccount:kube-system:endpoint-controller
+    verbs: ["get", "update"]
+    namespaces: ["kube-system"]
+    resources:
+      - group: "" # core
+        resources: ["endpoints"]
+  - level: None
+    users: ["system:apiserver"]
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["namespaces", "namespaces/status", "namespaces/finalize"]
+  - level: None
+    users: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+    namespaces: ["kube-system"]
+    resources:
+      - group: "" # core
+        resources: ["configmaps", "endpoints"]
+  # Don't log HPA fetching metrics.
+  - level: None
+    users:
+      - system:kube-controller-manager
+    verbs: ["get", "list"]
+    resources:
+      - group: "metrics.k8s.io"
+
+  # Don't log these read-only URLs.
+  - level: None
+    nonResourceURLs:
+      - /healthz*
+      - /version
+      - /swagger*
+
+  # Don't log events requests.
+  - level: None
+    resources:
+      - group: "" # core
+        resources: ["events"]
+
+  # node and pod status calls from nodes are high-volume and can be large, don't log responses for expected updates from nodes
+  - level: Request
+    users: ["kubelet", "system:node-problem-detector", "system:serviceaccount:kube-system:node-problem-detector"]
+    verbs: ["update","patch"]
+    resources:
+      - group: "" # core
+        resources: ["nodes/status", "pods/status"]
+    omitStages:
+      - "RequestReceived"
+  - level: Request
+    userGroups: ["system:nodes"]
+    verbs: ["update","patch"]
+    resources:
+      - group: "" # core
+        resources: ["nodes/status", "pods/status"]
+    omitStages:
+      - "RequestReceived"
+
+  # deletecollection calls can be large, don't log responses for expected namespace deletions
+  - level: Request
+    users: ["system:serviceaccount:kube-system:namespace-controller"]
+    verbs: ["deletecollection"]
+    omitStages:
+      - "RequestReceived"
+
+  # Secrets, ConfigMaps, and TokenReviews can contain sensitive & binary data,
+  # so only log at the Metadata level.
+  - level: Metadata
+    resources:
+      - group: "" # core
+        resources: ["secrets", "configmaps"]
+      - group: authentication.k8s.io
+        resources: ["tokenreviews"]
+    omitStages:
+      - "RequestReceived"
+  # Get repsonses can be large; skip them.
+  - level: Request
+    verbs: ["get", "list", "watch"]
+    resources: 
+      - group: "" # core
+      - group: "admissionregistration.k8s.io"
+      - group: "apiextensions.k8s.io"
+      - group: "apiregistration.k8s.io"
+      - group: "apps"
+      - group: "authentication.k8s.io"
+      - group: "authorization.k8s.io"
+      - group: "autoscaling"
+      - group: "batch"
+      - group: "certificates.k8s.io"
+      - group: "extensions"
+      - group: "metrics.k8s.io"
+      - group: "networking.k8s.io"
+      - group: "node.k8s.io"
+      - group: "policy"
+      - group: "rbac.authorization.k8s.io"
+      - group: "scheduling.k8s.io"
+      - group: "settings.k8s.io"
+      - group: "storage.k8s.io"
+    omitStages:
+      - "RequestReceived"
+  # Default level for known APIs
+  - level: RequestResponse
+    resources: 
+      - group: "" # core
+      - group: "admissionregistration.k8s.io"
+      - group: "apiextensions.k8s.io"
+      - group: "apiregistration.k8s.io"
+      - group: "apps"
+      - group: "authentication.k8s.io"
+      - group: "authorization.k8s.io"
+      - group: "autoscaling"
+      - group: "batch"
+      - group: "certificates.k8s.io"
+      - group: "extensions"
+      - group: "metrics.k8s.io"
+      - group: "networking.k8s.io"
+      - group: "node.k8s.io"
+      - group: "policy"
+      - group: "rbac.authorization.k8s.io"
+      - group: "scheduling.k8s.io"
+      - group: "settings.k8s.io"
+      - group: "storage.k8s.io"
+    omitStages:
+      - "RequestReceived"
+  # Default level for all other requests.
+  - level: Metadata
+    omitStages:
+      - "RequestReceived"

--- a/master_templates-v1.13.0-ubuntu/kube-apiserver
+++ b/master_templates-v1.13.0-ubuntu/kube-apiserver
@@ -2,9 +2,10 @@ APISERVER_OPTS="--enable-admission-plugins=NamespaceLifecycle,LimitRanger,Servic
 --allow-privileged=true \
 --apiserver-count=${ master_node_count } \
 --audit-log-maxage=30 \
---audit-log-maxbackup=3 \
---audit-log-maxsize=100 \
+--audit-log-maxbackup=9 \
+--audit-log-maxsize=1000 \
 --audit-log-path=/var/log/audit.log \
+--audit-policy-file=/etc/srv/kubernetes/audit-policy.yaml \
 --authorization-mode=Node,RBAC \
 --token-auth-file=/etc/srv/kubernetes/known_tokens.csv \
 --bind-address=0.0.0.0 \

--- a/master_templates-v1.13.0-ubuntu/master.tf
+++ b/master_templates-v1.13.0-ubuntu/master.tf
@@ -165,7 +165,7 @@ data "template_file" "master" {
     kube_scheduler_kubeconfig = "${ gzip_me.kube_scheduler_kubeconfig.output }"
     dns_conf = "${ gzip_me.dns_conf.output }"
     dns_dhcp = "${ gzip_me.dns_dhcp.output }"
-    audit_policy = "${ gzip_me.audit_policy.ouput }"
+    audit_policy = "${ gzip_me.audit_policy.output }"
 
   }
 }

--- a/master_templates-v1.13.0-ubuntu/master.tf
+++ b/master_templates-v1.13.0-ubuntu/master.tf
@@ -124,7 +124,15 @@ data "template_file" "kube_scheduler_kubeconfig" {
   }
 }
 
+resource "gzip_me" "audit_policy" {
+  input = "${ data.template_file.audit_policy.rendered }"
+}
 
+data "template_file" "audit_policy" {
+  template = "${ file( "${ path.module }/audit-policy.yaml" )}"
+  vars {
+  }
+}
 data "template_file" "master" {
   count = "${ var.master_node_count }"
   template = "${ file( "${ path.module }/master.yml" )}"
@@ -157,6 +165,7 @@ data "template_file" "master" {
     kube_scheduler_kubeconfig = "${ gzip_me.kube_scheduler_kubeconfig.output }"
     dns_conf = "${ gzip_me.dns_conf.output }"
     dns_dhcp = "${ gzip_me.dns_dhcp.output }"
+    audit_policy = "${ gzip_me.audit_policy.ouput }"
 
   }
 }

--- a/master_templates-v1.13.0-ubuntu/master.yml
+++ b/master_templates-v1.13.0-ubuntu/master.yml
@@ -234,3 +234,10 @@ write_files:
     content: |
       ${ dns_dhcp }
 
+  - path: /etc/srv/kubernetes/audit-policy.yaml
+    permissions: "0644"
+    encoding: "gzip+base64"
+    content: |
+      ${ audit_policy }
+
+ 


### PR DESCRIPTION
This should have the necessary changes to enable audit-log support. 

Is there a way to access the image that this will produce so we could see the audit-logs? 